### PR TITLE
[JBPM-8549] - Adding test cases mocking kubernetes api calls to be ab…

### DIFF
--- a/kogito-cloud-services/kogito-cloud-workitems/pom.xml
+++ b/kogito-cloud-services/kogito-cloud-workitems/pom.xml
@@ -40,5 +40,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Fabric8 client used exclusively for tests purposes only -->
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <version>${version.kubernetes-client}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseKubernetesDiscoveredServiceTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseKubernetesDiscoveredServiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.cloud.workitems;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.After;
+import org.junit.Before;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemManager;
+
+/**
+ * Base class for tests with Kubernetes API. In this scenario, nor Istio or KNative is available.
+ */
+public abstract class BaseKubernetesDiscoveredServiceTest {
+
+    public KubernetesServer server = new KubernetesServer(true, true);
+
+    public static final String MOCK_NAMESPACE = "mock-namespace";
+
+    // will be changed to junit5 extensions once migrated
+    @Before
+    public void before() {
+        server.before();
+    }
+
+    // will be changed to junit5 extensions once migrated
+    @After
+    public void after() {
+        server.after();
+    }
+
+    protected KubernetesClient getClient() {
+
+        return server.getClient().inNamespace(MOCK_NAMESPACE);
+    }
+
+    protected static class TestDiscoveredServiceWorkItemHandler extends DiscoveredServiceWorkItemHandler {
+
+        private final BaseKubernetesDiscoveredServiceTest testCase;
+
+        public TestDiscoveredServiceWorkItemHandler(BaseKubernetesDiscoveredServiceTest testCase) {
+            super();
+            this.testCase = testCase;
+        }
+
+        @Override
+        public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {}
+
+        @Override
+        public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {}
+
+        @Override
+        protected KubernetesClient getKubeClient() {
+            this.istionGatewayClusterIp = null;
+            return this.testCase.getClient();
+        }
+
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.cloud.workitems;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class KubernetesDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesDiscoveredServiceTest {
+
+    @Test
+    public void testGivenServiceExists() {
+        final ServiceSpec serviceSpec = new ServiceSpec();
+        serviceSpec.setPorts(Collections.singletonList(new ServicePort("http", 0, 8080, "http", new IntOrString(8080))));
+        serviceSpec.setClusterIP("172.30.158.31");
+        serviceSpec.setType("ClusterIP");
+        serviceSpec.setSessionAffinity("ClientIP");
+
+        final ObjectMeta metadata = new ObjectMeta();
+        metadata.setName("test-kieserver");
+        metadata.setNamespace(MOCK_NAMESPACE);
+        metadata.setLabels(Collections.singletonMap("service", "test-kieserver"));
+
+        final Service service = new Service("v1", "Service", metadata, serviceSpec, new ServiceStatus(new LoadBalancerStatus()));
+        getClient().services().create(service);
+
+        final DiscoveredServiceWorkItemHandler handler = new TestDiscoveredServiceWorkItemHandler(this);
+        final ServiceInfo serviceInfo = handler.findEndpoint(MOCK_NAMESPACE, "test-kieserver");
+        assertThat(serviceInfo, notNullValue());
+        assertThat(serviceInfo.getUrl(), is("http://172.30.158.31:8080/test-kieserver"));
+    }
+
+    @Test
+    public void testGivenServiceNotExists() throws IOException {
+        final DiscoveredServiceWorkItemHandler handler = new TestDiscoveredServiceWorkItemHandler(this);
+        try {
+            handler.findEndpoint(MOCK_NAMESPACE, "test-kieserver");
+            fail("Finding of non existing endpoint should throw RuntimeException.");
+        } catch (RuntimeException ex) {
+            assertThat(ex.getMessage(), containsString("No endpoint found"));
+        }
+    }
+}


### PR DESCRIPTION
…le to replace clients in the future, preserving behavior

See: https://issues.jboss.org/browse/JBPM-8549

Signed-off-by: Ricardo Zanini <zanini@redhat.com>