### PR TITLE
[JBPM-8549] - Introducing Kogito Kubernetes Client

### DIFF
--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/.gitignore
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/.gitignore
@@ -1,0 +1,32 @@
+bin/
+/target
+/local
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store
+
+# Original jbpm ignores
+*~
+
+# Test info
+/settings*.xml
+/lib-jdbc/
+*.db
+*.tlog
+
+# modules that don't exist in this branch
+/jbpm-human-task-war/
+/jbpm-bam/
+/jbpm-gwt/
+
+# files used for external db testing
+jdbc_driver.jar
+db-settings.xml

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/README.md
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/README.md
@@ -1,0 +1,10 @@
+# Kogito Cloud Kubernetes Client
+
+This library is designed to be used with Kogito Cloud module, but also as a standalone library as an alternative Kubernetes client on [native images](https://www.graalvm.org/docs/reference-manual/aot-compilation/).
+
+It's a wrapper around the [Fabric8 Kubernetes Client API](https://github.com/fabric8io/kubernetes-client), with some tweaks:
+
+1. Removes the Kube Config file parsing as an alternative to connect to the cluster because of [its reflection usage](https://github.com/fabric8io/kubernetes-client/issues/1591).
+2. Parse JSON API responses as simple Maps to avoid using reflection to build domain objects during runtime like Jackson does. As an alternative, uses Yasson to parse JSON responses and a simple utility to walk into the resulted map.
+
+It's meant to be simple to support simple use cases.

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/pom.xml
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/pom.xml
@@ -7,9 +7,9 @@
     <artifactId>kogito-cloud-services</artifactId>
     <version>8.0.0-SNAPSHOT</version>
   </parent>
-  <artifactId>kogito-cloud-workitems</artifactId>
-  <name>Kogito Cloud Work Items</name>
-  <description>Kogito Cloud Work Items</description>
+  <artifactId>kogito-cloud-kubernetes-client</artifactId>
+  <name>Kogito Cloud Kubernetes Client</name>
+  <description>Kogito Cloud Kubernetes Client</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -17,14 +17,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-api</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.kie.kogito</groupId>
-      <artifactId>kogito-cloud-kubernetes-client</artifactId>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
@@ -40,19 +39,17 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <version>${version.kubernetes-client}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Logging -->
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Fabric8 client used exclusively for tests purposes only -->
-    <dependency>
-      <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-server-mock</artifactId>
-      <version>${version.kubernetes-client}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/DefaultKogitoKubeClient.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/DefaultKogitoKubeClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+import org.kie.kogito.cloud.kubernetes.client.operations.IstioGatewayOperations;
+import org.kie.kogito.cloud.kubernetes.client.operations.KNativeServiceOperations;
+import org.kie.kogito.cloud.kubernetes.client.operations.ServiceOperations;
+
+/**
+ * Default {@link KogitoKubeClient} implementation.
+ */
+public class DefaultKogitoKubeClient implements KogitoKubeClient {
+
+    private ServiceOperations serviceOperation;
+    private IstioGatewayOperations istioGatewayOperations;
+    private KNativeServiceOperations kNativeServiceOperations;
+    private KogitoKubeConfig clientConfig;
+
+    public DefaultKogitoKubeClient() {
+        this.clientConfig = new KogitoKubeConfig();
+    }
+
+    @Override
+    public KogitoKubeConfig getConfig() {
+        return this.clientConfig;
+    }
+
+    @Override
+    public DefaultKogitoKubeClient withConfig(KogitoKubeConfig clientConfig) {
+        this.clientConfig = clientConfig;
+        return this;
+    }
+
+    /**
+     * The Services Operations
+     */
+    @Override
+    public ServiceOperations services() {
+        if (serviceOperation == null) {
+            this.serviceOperation = new ServiceOperations(clientConfig);
+        }
+        return this.serviceOperation;
+    }
+
+    @Override
+    public IstioGatewayOperations istioGateway() {
+        if (istioGatewayOperations == null) {
+            this.istioGatewayOperations = new IstioGatewayOperations(clientConfig);
+        }
+        return this.istioGatewayOperations;
+    }
+
+    @Override
+    public KNativeServiceOperations knativeService() {
+        if (kNativeServiceOperations == null) {
+            this.kNativeServiceOperations = new KNativeServiceOperations(clientConfig);
+        }
+        return this.kNativeServiceOperations;
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/KogitoKubeClient.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/KogitoKubeClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+import org.kie.kogito.cloud.kubernetes.client.operations.IstioGatewayOperations;
+import org.kie.kogito.cloud.kubernetes.client.operations.KNativeServiceOperations;
+import org.kie.kogito.cloud.kubernetes.client.operations.ServiceOperations;
+
+/**
+ * Main interface to communicate with Kubernetes Cluster API.
+ */
+public interface KogitoKubeClient {
+
+    ServiceOperations services();
+
+    IstioGatewayOperations istioGateway();
+
+    KNativeServiceOperations knativeService();
+
+    KogitoKubeClient withConfig(KogitoKubeConfig config);
+
+    KogitoKubeConfig getConfig();
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/KogitoKubeClientException.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/KogitoKubeClientException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+/**
+ * Generic exception for the Kube Client
+ */
+public class KogitoKubeClientException extends RuntimeException {
+
+    private static final long serialVersionUID = 5121838037390778349L;
+
+    public KogitoKubeClientException() {}
+
+    public KogitoKubeClientException(String message) {
+        super(message);
+    }
+
+    public KogitoKubeClientException(Throwable cause) {
+        super(cause);
+    }
+
+    public KogitoKubeClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public KogitoKubeClientException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/KogitoKubeConfig.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/KogitoKubeConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import io.fabric8.kubernetes.client.BaseClient;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.OperationSupport;
+import okhttp3.OkHttpClient;
+
+/**
+ * Wraps the Kubernetes Client setup and configuration, exposing infrastructure components to connect to a Kubernetes cluster reliably. 
+ * Most used when there's a need to customize the Fabric8 Kubernetes Client.
+ */
+public final class KogitoKubeConfig {
+
+    public static final String KNATIVE_ISTIO_NAMESPACE = "istio-system";
+    private static final String NAMESPACE_REPLACE = "@ns@";
+    private static final String KNATIVE_SERVICE_SERVICE_URL = "apis/serving.knative.dev/v1alpha1/namespaces/" + NAMESPACE_REPLACE + "/services";
+    private static final String KNATIVE_ISTIO_GATEWAY_URL = "api/v1/namespaces/" + KNATIVE_ISTIO_NAMESPACE + "/services/istio-ingressgateway";
+
+    private KubernetesClient kubernetesClient;
+
+    public KogitoKubeConfig() {
+        // disable kube config file deserialization due to reflection usage
+        System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
+        this.kubernetesClient = new DefaultKubernetesClient();
+    }
+
+    /**
+     * Highly customizable config client. Most used in integration tests. 90% of the time you won't need to use this constructor.
+     * 
+     * @param kubernetesClient
+     */
+    public KogitoKubeConfig(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
+
+    public OkHttpClient getHttpClient() {
+        return ((BaseClient) this.kubernetesClient).getHttpClient();
+    }
+
+    public URL getMasterUrl() {
+        return this.kubernetesClient.getMasterUrl();
+    }
+
+    public String getKNativeServiceServiceURL(String namespace) throws MalformedURLException {
+        if (namespace == null || namespace.isEmpty()) {
+            throw new IllegalArgumentException("A namespace should be provided when using KNative service operations");
+        }
+        final StringBuilder sb = new StringBuilder(this.getMasterUrl().toString());
+        sb.append(KNATIVE_SERVICE_SERVICE_URL.replaceFirst(NAMESPACE_REPLACE, namespace));
+        return sb.toString();
+    }
+
+    public String getKNativeIstioGatewayURL() throws MalformedURLException {
+        final StringBuilder sb = new StringBuilder(this.getMasterUrl().toString());
+        sb.append(KNATIVE_ISTIO_GATEWAY_URL);
+        return sb.toString();
+    }
+
+    public URL getServiceOperationURL(final String namespace) throws MalformedURLException {
+        final OperationSupport services = ((OperationSupport) this.kubernetesClient.services());
+        return services.getNamespacedUrl(namespace);
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/OperationsUtils.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/OperationsUtils.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+public final class OperationsUtils {
+
+    public static final String LABEL_SELECTOR_PARAM = "labelSelector";
+
+    private OperationsUtils() {}
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/BaseListOperations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/BaseListOperations.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.util.Map;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
+
+public abstract class BaseListOperations extends BaseOperations implements ListOperations {
+
+    public BaseListOperations(KogitoKubeConfig clientConfig) {
+        super(clientConfig);
+    }
+
+    @Override
+    public OperationsResponseParser listNamespaced(String namespace, Map<String, String> labels) {
+        return this.execute(namespace, labels);
+    }
+
+    @Override
+    public OperationsResponseParser list(Map<String, String> labels) {
+        return this.listNamespaced(null, labels);
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/BaseOperations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/BaseOperations.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import okhttp3.Request;
+import okhttp3.Response;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClientException;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
+import org.kie.kogito.cloud.kubernetes.client.OperationsUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for all operations
+ */
+public abstract class BaseOperations implements Operations {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseOperations.class);
+    private static final String EMPTY_JSON = "{}";
+
+    private final KogitoKubeConfig clientConfig;
+
+    public BaseOperations(final KogitoKubeConfig clientConfig) {
+        this.clientConfig = clientConfig;
+    }
+
+    public final KogitoKubeConfig getClientConfig() {
+        return clientConfig;
+    }
+
+    private URL doBuildUrl(final String namespace, final Map<String, String> labels) {
+        try {
+            StringBuilder sb = new StringBuilder(this.buildBaseUrl(namespace));
+            if (labels != null) {
+                sb.append("?").append(OperationsUtils.LABEL_SELECTOR_PARAM).append("=");
+                sb.append(this.buildLabelSelectorParam(labels));
+            }
+            return new URL(sb.toString());
+        } catch (Exception e) {
+            throw new KogitoKubeClientException(String.format("Error while trying to build URL for the Service API: '%s'", e.getMessage()), e);
+        }
+    }
+
+    private String buildLabelSelectorParam(final Map<String, String> labels) {
+        if (labels != null) {
+            return labels.entrySet()
+                         .stream()
+                         .map(label -> String.format(label.getValue() == null || label.getValue().isEmpty() ? "%s" : "%s=%s", label.getKey(), label.getValue()))
+                         .collect(Collectors.joining(","));
+        }
+        return "";
+    }
+
+    private Response doExecute(final String namespace, final Map<String, String> labels) throws IOException {
+        final URL url = this.doBuildUrl(namespace, labels);
+        final Request request = new Request.Builder().url(url).build();
+
+        LOGGER.debug("About to query the Kubernetes API with url {} with label selector {} in namespace  '{}'", url, labels, namespace);
+
+        return clientConfig.getHttpClient().newCall(request).execute();
+    }
+
+    protected OperationsResponseParser execute(final String namespace, final Map<String, String> labels) {
+        try (Response response = this.doExecute(namespace, labels)) {
+            LOGGER.debug("Response Headers received from the Kube cluster: {}", response.headers());
+            if (response.isSuccessful()) {
+                final String data = response.body().string();
+                LOGGER.debug("Received response data from Kube API: {}", data);
+                return new OperationsResponseParser(data);
+            }
+            if (response.code() == HttpURLConnection.HTTP_NOT_FOUND) {
+                LOGGER.debug("No resources found in namespace '{}' with labels {}", namespace, labels);
+                return new OperationsResponseParser(EMPTY_JSON);
+            }
+            if (response.code() == HttpURLConnection.HTTP_FORBIDDEN || response.code() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                throw new KogitoKubeClientException(String.format("Tried to fetch for resources, got unauthorized/forbidden response: %s. Make sure to correctly set a Service Account with permissions to fetch the resource.",
+                                                                  response));
+            }
+            throw new KogitoKubeClientException(String.format("Error trying to fetch the Kubernetes API. Response is: %s", response));
+        } catch (KogitoKubeClientException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new KogitoKubeClientException(String.format("Error trying to fetch the Kubernetes API - '%s: %s'", e.getClass(), e.getMessage()), e);
+        }
+    }
+
+    /**
+     * URL builder for the API calls. Normally composed by the Master URL + Resource Path.
+     * 
+     * @param namespace
+     * @return
+     * @throws MalformedURLException
+     * @see {@link ServiceOperations#buildBaseUrl(String)}
+     */
+    protected abstract String buildBaseUrl(final String namespace) throws MalformedURLException;
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/IstioGatewayOperations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/IstioGatewayOperations.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.net.MalformedURLException;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
+
+public class IstioGatewayOperations extends BaseOperations {
+
+    public IstioGatewayOperations(final KogitoKubeConfig config) {
+        super(config);
+    }
+
+    public OperationsResponseParser get() {
+        return this.execute(null, null);
+    }
+
+    @Override
+    protected String buildBaseUrl(String namespace) throws MalformedURLException {
+        return this.getClientConfig().getKNativeIstioGatewayURL();
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/KNativeServiceOperations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/KNativeServiceOperations.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.net.MalformedURLException;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
+
+public class KNativeServiceOperations extends BaseListOperations {
+
+    public KNativeServiceOperations(KogitoKubeConfig clientConfig) {
+        super(clientConfig);
+    }
+
+    @Override
+    protected String buildBaseUrl(String namespace) throws MalformedURLException {
+        return this.getClientConfig().getKNativeServiceServiceURL(namespace);
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/ListOperations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/ListOperations.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.util.Map;
+
+/**
+ * Operations that return a list of objects. Normally a <code>kind: List</code> with <code>items</code> attribute.
+ */
+public interface ListOperations extends Operations {
+
+    /**
+     * Query for a list of services within a namespace.
+     * 
+     * @param namespace
+     * @param labels
+     * @return A JSON Document reference of the Service API response
+     */
+    OperationsResponseParser listNamespaced(final String namespace, final Map<String, String> labels);
+
+    /**
+     * Queries for a list of services in the entire cluster. A service account with permissions to query the cluster might be needed. 
+     * 
+     * @param labels
+     * @return A JSON Document reference of the Service API response
+     */
+    OperationsResponseParser list(final Map<String, String> labels);
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/MapWalker.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/MapWalker.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility to avoid chaining conversion in code
+ */
+@SuppressWarnings("unchecked")
+public final class MapWalker {
+
+    private Object theMap;
+    private boolean safeNull;
+
+    /**
+     * Walker with safe null
+     * @param theMap that we're going to walk into
+     * @param safeNull whether to return a null value at the end of the walk, otherwise if the key isn't expected a NPE or an {@link IllegalArgumentException} might raise.
+     */
+    public MapWalker(Object theMap, boolean safeNull) {
+        this.theMap = theMap;
+        this.safeNull = safeNull;
+    }
+
+    public MapWalker(Object theMap) {
+        this(theMap, false);
+    }
+
+    /**
+     * Return the object as a Map.
+     * @param <K>
+     * @param <V>
+     * @return
+     */
+    public <K, V> Map<K, V> asMap() {
+        if (theMap instanceof Map) {
+            return (Map<K, V>) theMap;
+        }
+        throw new IllegalArgumentException(String.format("The object %s is not a map. Impossible to get", theMap));
+    }
+
+    /**
+     * Return the object as a list
+     * @param <K>
+     * @param <V>
+     * @return
+     */
+    public <K, V> List<Map<K, V>> asList() {
+        if (theMap instanceof List) {
+            return (List<Map<K, V>>) theMap;
+        }
+        throw new IllegalArgumentException(String.format("The object %s is not a list. Impossible to get", theMap));
+    }
+
+    /**
+     * The key value is another map 
+     */
+    public MapWalker mapToMap(String key) {
+        if (theMap instanceof Map) {
+            this.theMap = ((Map<String, ?>) theMap).get(key);
+            if (safeNull && this.theMap == null) {
+                this.theMap = new HashMap<>();
+            }
+            return this;
+        }
+        throw new IllegalArgumentException(String.format("The object %s is not a map. Impossible to walk to the key '%s'", theMap, key));
+    }
+
+    /**
+     * The key value is a list map.
+     * 
+     * @param key
+     * @return
+     */
+    public MapWalker mapToListMap(final String key) {
+        if (theMap instanceof Map) {
+            theMap = (List<Map<?, ?>>) ((Map<?, ?>) theMap).get(key);
+            if (safeNull && this.theMap == null) {
+                this.theMap = new ArrayList<Map<?, ?>>();
+            }
+            return this;
+        }
+        throw new IllegalArgumentException(String.format("The object %s is not a list. Impossible to walk to the key %s", theMap, key));
+    }
+
+    /**
+     * In a list, we take the index that is a map
+     * @param index
+     * @return
+     */
+    public MapWalker listToMap(final int index) {
+        if (theMap instanceof List) {
+            final List<Map<?, ?>> theList = ((List<Map<?, ?>>) theMap);
+            if (theList != null && theList.size() > index) {
+                theMap = (Map<?, ?>) theList.get(index);
+            } else {
+                this.theMap = new HashMap<>();
+            }
+
+            return this;
+        }
+        throw new IllegalArgumentException(String.format("The object %s is not a list. Impossible to walk to the index '%d'", theMap, index));
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/Operations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/Operations.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+/**
+ * Common interface for operations on the Kubernetes API.
+ */
+public interface Operations {
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/OperationsResponseParser.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/OperationsResponseParser.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OperationsResponseParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationsResponseParser.class);
+
+    private final String response;
+    private final ObjectMapper mapper;
+
+    public OperationsResponseParser(final String response) {
+        this.response = response;
+        this.mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
+    }
+
+    /**
+     * Returns the raw JSON Document Response from the API
+     *  
+     * @return
+     */
+    public String asJson() {
+        return response;
+    }
+
+    /**
+     * Returns the JSON Document as a list of map
+     * 
+     * @return
+     */
+    public Map<String, Object> asMap() {
+        if (response == null || response.isEmpty()) {
+            return new HashMap<>();
+        }
+        try {
+            final TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
+            };
+            LOGGER.debug("Trying to parse API response {}", response);
+            return mapper.readValue(response, typeRef);
+        } catch (IOException e) {
+            throw new KogitoKubeClientException("Error while trying to parse API response", e);
+        }
+    }
+
+    /**
+     * Default {@link MapWalker} that explodes an {@link IllegalArgumentException} in case the wrong path is taken
+     * 
+     * @return
+     */
+    public MapWalker asMapWalker() {
+        return this.asMapWalker(false);
+    }
+
+    /**
+     * A {@link MapWalker} with the option to turn on/off safe nulls
+     * @param safeNull
+     * @return
+     */
+    public MapWalker asMapWalker(final boolean safeNull) {
+        if (response == null || response.isEmpty()) {
+            return new MapWalker(new HashMap<>(), safeNull);
+        }
+        return new MapWalker(this.asMap(), safeNull);
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperations.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperations.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.net.MalformedURLException;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
+
+/**
+ * Wrapper for service operations on Kubernetes Client that resolves the responses from the API calls to Maps.
+ * @see <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#service-v1-core">Kubernetes API Reference - Services</a>
+ */
+public class ServiceOperations extends BaseListOperations {
+
+    public ServiceOperations(final KogitoKubeConfig clientConfig) {
+        super(clientConfig);
+    }
+
+    @Override
+    protected String buildBaseUrl(String namespace) throws MalformedURLException {
+        return this.getClientConfig().getServiceOperationURL(namespace).toExternalForm();
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/KubeClientConfigTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/KubeClientConfigTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class KubeClientConfigTest {
+
+    public static final Path KUBE_CONFIG_PATH = Paths.get(System.getProperty("user.home") + "/.kube/config");
+    public static final Path KUBE_CONFIG_DIR = Paths.get(System.getProperty("user.home") + "/.kube");
+
+    @Before
+    public void setup() throws IOException {
+        if (!Files.exists(KUBE_CONFIG_PATH)) {
+            if(!Files.exists(KUBE_CONFIG_DIR)) {
+                Files.createDirectories(KUBE_CONFIG_DIR);
+            }
+            Files.createFile(KUBE_CONFIG_PATH);
+        }
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (Files.exists(KUBE_CONFIG_PATH) && Files.readAllBytes(KUBE_CONFIG_PATH).length == 0) {
+            Files.delete(KUBE_CONFIG_PATH);
+            Files.delete(KUBE_CONFIG_DIR);
+        }
+        System.clearProperty("kubernetes.master");
+    }
+
+    @Test
+    public void whenCreateNewConfigurationIgnoresKubeConfigFile() {
+        final KogitoKubeConfig config = new KogitoKubeConfig();
+        assertThat(config.getHttpClient(), notNullValue());
+        assertThat(config.getMasterUrl().toString(), containsString("kubernetes.default.svc"));
+    }
+
+    @Test
+    public void whenGetFromSystemProps() {
+        System.setProperty("kubernetes.master", "localhost");
+        final KogitoKubeConfig config = new KogitoKubeConfig();
+        assertThat(config.getMasterUrl().toString(), containsString("localhost"));
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/MockKubernetesServerSupport.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/MockKubernetesServerSupport.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Base class to test use cases that need to query the API
+ */
+public abstract class MockKubernetesServerSupport {
+
+    public static final String MOCK_NAMESPACE = "test";
+    private KubernetesServer server;
+    private KogitoKubeClient kubeClient;
+
+    public MockKubernetesServerSupport() {
+        this.initializeServer(true);
+    }
+
+    public MockKubernetesServerSupport(final boolean crudMode) {
+        this.initializeServer(crudMode);
+    }
+
+    public KogitoKubeClient getKubeClient() {
+        return this.kubeClient;
+    }
+
+    public KubernetesServer getServer() {
+        return server;
+    }
+
+    /**
+     * Override to setup a different kind of server
+     */
+    protected final void initializeServer(final boolean crudMode) {
+        this.server = new KubernetesServer(false, crudMode);
+    }
+
+    @Before
+    public void before() {
+        server.before();
+        this.kubeClient = new DefaultKogitoKubeClient().withConfig(new KogitoKubeConfig(server.getClient()));
+    }
+
+    @After
+    public void after() {
+        server.after();
+    }
+
+    /**
+     * Creates a new mock service in the {@value #MOCK_NAMESPACE} with 127.0.0.1:8080 address
+     */
+    protected void createMockService() {
+        this.createMockService("test", "127.0.0.1", Collections.singletonMap("service", "test"), MOCK_NAMESPACE);
+    }
+
+    /**
+     * Same as {@link #createMockService()}, but let you choose the namespace. 
+     * @param namespace null to not specify where.
+     */
+    protected void createMockService(final String namespace) {
+        this.createMockService("test", "127.0.0.1", Collections.singletonMap("service", "test"), namespace);
+    }
+
+    /**
+     * Creates a service based on an {@link InputStream} of a json service response.
+     * 
+     * @param mockJsonResponse
+     */
+    protected void createMockService(final InputStream mockJsonResponse, final String namespace) {
+        final ServiceResource<Service, ?> serviceResource = this.server.getClient().inNamespace(namespace).services().load(mockJsonResponse);
+        this.server.getClient().inNamespace(namespace).services().create(serviceResource.get());
+    }
+
+    /**
+     * Creates a list of services based on a {@link InputStream} of a json servicelist response
+     * 
+     * @param mockJsonResponse
+     * @param namespace
+     */
+    protected void createMockServices(final InputStream mockJsonResponse, final String namespace) {
+        final RecreateFromServerGettable<KubernetesList, KubernetesList, ?> serviceResource = this.server.getClient().inNamespace(namespace).lists().load(mockJsonResponse);
+        this.server.getClient().inNamespace(namespace).lists().create(serviceResource.get());
+    }
+
+    protected void createMockService(final String serviceName, final String ip, final Map<String, String> labels, final String namespace) {
+        final ServiceSpec serviceSpec = new ServiceSpec();
+        serviceSpec.setPorts(Collections.singletonList(new ServicePort("http", 0, 8080, "http", new IntOrString(8080))));
+        serviceSpec.setClusterIP(ip);
+        serviceSpec.setType("ClusterIP");
+        serviceSpec.setSessionAffinity("ClientIP");
+
+        final ObjectMeta metadata = new ObjectMeta();
+        metadata.setName(serviceName);
+        metadata.setNamespace(MOCK_NAMESPACE);
+        metadata.setLabels(labels);
+
+        final Service service = new Service("v1", "Service", metadata, serviceSpec, new ServiceStatus(new LoadBalancerStatus()));
+        if (namespace != null) {
+            this.server.getClient().inNamespace(namespace).services().create(service);
+        } else {
+            this.server.getClient().services().create(service);
+        }
+
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/MapWalkerTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/MapWalkerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class MapWalkerTest {
+
+    public MapWalkerTest() {
+
+    }
+
+    @Test
+    public void whenMapIsEmptyAndIsSafe() {
+        final MapWalker walker = new MapWalker(new HashMap<>(), true);
+        assertThat(walker.mapToListMap("test").listToMap(0).asMap(), notNullValue());
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void whenMapIsEmptyAndIsNotSafe() {
+        final MapWalker walker = new MapWalker(new HashMap<>());
+       walker.mapToListMap("test").listToMap(0).asMap();
+       fail("Should explode an exception while is not safe walking through an empty map");
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsStatusCodeHandlingTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsStatusCodeHandlingTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.net.HttpURLConnection;
+import java.util.Map;
+
+import org.junit.Test;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClientException;
+import org.kie.kogito.cloud.kubernetes.client.MockKubernetesServerSupport;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases where
+ */
+public class ServiceOperationsStatusCodeHandlingTest extends MockKubernetesServerSupport {
+
+    public ServiceOperationsStatusCodeHandlingTest() {
+        super(false);
+    }
+
+    @Test
+    public void whenNotFoundResponse() {
+        getServer().expect().get().withPath("/api/v1/services").andReturn(404, null).once();
+        Map<String, Object> services = this.getKubeClient().services().list(null).asMap();
+        assertThat(services, notNullValue());
+        assertThat(services.size(), is(0));
+    }
+
+    @Test
+    public void whenForbiddenResponse() {
+        try {
+            getServer().expect().get().withPath("/api/v1/services").andReturn(HttpURLConnection.HTTP_FORBIDDEN, null).once();
+            this.getKubeClient().services().list(null).asMap();
+            fail("Should explode a forbidden exception");
+        } catch (KogitoKubeClientException e) {
+            assertThat(e.getMessage(), containsString("forbidden"));
+        }
+    }
+
+    @Test
+    public void whenUnauthorizedResponse() {
+        try {
+            getServer().expect().get().withPath("/api/v1/services").andReturn(HttpURLConnection.HTTP_UNAUTHORIZED, null).once();
+            this.getKubeClient().services().list(null).asMap();
+            fail("Should explode a forbidden exception");
+        } catch (KogitoKubeClientException e) {
+            assertThat(e.getMessage(), containsString("unauthorized"));
+        }
+    }
+
+    @Test(expected = KogitoKubeClientException.class)
+    public void whenServerError() {
+        getServer().expect().get().withPath("/api/v1/services").andReturn(HttpURLConnection.HTTP_BAD_GATEWAY, null).once();
+        this.getKubeClient().services().list(null).asMap();
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.operations;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.kie.kogito.cloud.kubernetes.client.MockKubernetesServerSupport;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ServiceOperationsTest extends MockKubernetesServerSupport {
+
+    private void assertDefaultServiceCreated(final String services) throws JsonParseException, JsonMappingException, IOException {
+        this.assertDefaultServiceCreated(services, "127.0.0.1");
+    }
+
+    private void assertDefaultServiceCreated(final String services, final String assertIp) throws JsonParseException, JsonMappingException, IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        assertThat(services, notNullValue());
+        assertThat(services.isEmpty(), not(true));
+        final TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {
+        };
+        Map<String, Object> servicesMap = mapper.readValue(services, typeRef);
+        Map<String, Object> spec =
+                new MapWalker(servicesMap)
+                                          .mapToListMap("items")
+                                          .listToMap(0)
+                                          .mapToMap("spec")
+                                          .asMap();
+        assertThat(spec.get("clusterIP"), is(assertIp));
+        assertThat(Integer.parseInt(new MapWalker(spec).mapToListMap("ports").listToMap(0).asMap().get("port").toString()), is(8080));
+    }
+
+    @Test
+    public void whenThereIsOneSingleServiceNamespaced() throws JsonParseException, JsonMappingException, IOException {
+        this.createMockService();
+        String services = this.getKubeClient().services().listNamespaced(MOCK_NAMESPACE, null).asJson();
+        this.assertDefaultServiceCreated(services);
+    }
+
+    @Test
+    public void whenThereIsAListOfServicesNamespaced() throws JsonParseException, JsonMappingException, IOException {
+        this.createMockService();
+        this.createMockService("service2", "192.168.0.1", Collections.singletonMap("service", "test2"), MOCK_NAMESPACE);
+        String services = this.getKubeClient().services().listNamespaced(MOCK_NAMESPACE, null).asJson();
+        this.assertDefaultServiceCreated(services, "192.168.0.1");
+    }
+    
+    @Test
+    public void whenThereIsAListOfServicesNamespacedLookingForLabelKey() throws JsonParseException, JsonMappingException, IOException {
+        this.createMockService("service2", "192.168.0.1", Collections.singletonMap("service", null), MOCK_NAMESPACE);
+        String services = this.getKubeClient().services().listNamespaced(MOCK_NAMESPACE, Collections.singletonMap("service", null)).asJson();
+        this.assertDefaultServiceCreated(services, "192.168.0.1");
+    }
+
+    @Test
+    public void whenThereIsAListOfServicesNamespacedWithLabel() throws JsonParseException, JsonMappingException, IOException {
+        this.createMockService();
+        this.createMockService("service2", "192.168.0.1", Collections.singletonMap("service", "test2"), MOCK_NAMESPACE);
+        String servicesJson = this.getKubeClient()
+                                  .services()
+                                  .listNamespaced(MOCK_NAMESPACE, Collections.singletonMap("service", "test2"))
+                                  .asJson();
+        this.assertDefaultServiceCreated(servicesJson, "192.168.0.1");
+    }
+
+    @Test
+    public void whenThereIsOneServiceNamespacedReturnedAsMap() {
+        this.createMockService();
+        Map<String, Object> services =
+                this.getKubeClient()
+                    .services()
+                    .listNamespaced(MOCK_NAMESPACE, null)
+                    .asMap();
+        assertThat(services, notNullValue());
+        assertThat(services.size(), is(3));
+        assertThat(services.get("items"), instanceOf(ArrayList.class));
+    }
+
+    @Test
+    public void whenThereIsOneSingleService() throws JsonParseException, JsonMappingException, IOException {
+        this.createMockService("");
+        String services = this.getKubeClient().services().list(null).asJson();
+        this.assertDefaultServiceCreated(services);
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/resources/logback-test.xml
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandler.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandler.java
@@ -24,60 +24,70 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import org.kie.api.runtime.process.WorkItem;
-import org.kie.api.runtime.process.WorkItemHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
-
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.kogito.cloud.kubernetes.client.DefaultKogitoKubeClient;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
+import org.kie.kogito.cloud.workitems.service.discovery.ServiceDiscovery;
+import org.kie.kogito.cloud.workitems.service.discovery.ServiceDiscoveryFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class DiscoveredServiceWorkItemHandler implements WorkItemHandler {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DiscoveredServiceWorkItemHandler.class);
-    
+
     protected static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     protected static final List<String> INTERNAL_FIELDS = Arrays.asList("TaskName", "ActorId", "GroupId", "Priority", "Comment", "Skippable", "Content", "Model", "Namespace");
-    
-    protected static final String KNATIVE_SERVICE_SERVICE_URL = "apis/serving.knative.dev/v1alpha1/namespaces/@ns@/services?labelSelector=";
-    protected static final String KNATIVE_ISTIO_GATEWAY_URL = "api/v1/namespaces/istio-system/services/istio-ingressgateway";
-    protected static final String SERVICE_URL = "api/v1/namespaces/@ns@/services?labelSelector=";
-    
-    protected String istionGatewayClusterIp;
-    
+
     protected Map<String, ServiceInfo> serviceEndpoints = new ConcurrentHashMap<>();
-    
-    private volatile KubernetesClient client;
+
     private OkHttpClient http;
     private ObjectMapper mapper = new ObjectMapper();
+    private ServiceDiscovery serviceDiscovery;
 
-    
     public DiscoveredServiceWorkItemHandler() {
+        this(null);
+    }
+
+    protected DiscoveredServiceWorkItemHandler(final KogitoKubeClient kubeClient) {
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         mapper.setDateFormat(new StdDateFormat().withColonInTimeZone(true));
-        
+
         http = buildHttpClient();
+
+        if (kubeClient == null) {
+            serviceDiscovery = this.buildServiceDiscovery(new DefaultKogitoKubeClient());
+        } else {
+            serviceDiscovery = this.buildServiceDiscovery(kubeClient);
+        }
     }
-    
+
+    /**
+     * Returns the {@link ServiceDiscovery} reference that will be used during the endpoint discovery.
+     * @return
+     */
+    protected ServiceDiscovery buildServiceDiscovery(KogitoKubeClient kubeClient) {
+        return ServiceDiscoveryFactory.build(kubeClient);
+    }
+
     protected OkHttpClient buildHttpClient() {
         return new OkHttpClient.Builder()
-                .connectTimeout(60, TimeUnit.SECONDS)
-                .writeTimeout(60, TimeUnit.SECONDS)
-                .readTimeout(60, TimeUnit.SECONDS)
-                .build();
+                                         .connectTimeout(60, TimeUnit.SECONDS)
+                                         .writeTimeout(60, TimeUnit.SECONDS)
+                                         .readTimeout(60, TimeUnit.SECONDS)
+                                         .build();
     }
-    
+
     /**
      * Looks up service's endpoint (cluster ip + port) using label selector - meaning returns services that have given label.
      * Services are looked up only in given namespace. 
@@ -85,64 +95,7 @@ public abstract class DiscoveredServiceWorkItemHandler implements WorkItemHandle
      * @return valid endpoint (in URL form) if found or runtime exception in case of no services found
      */
     protected ServiceInfo findEndpoint(String namespace, String service) {
-        
-        LOGGER.debug("Looking up for service {} in namespace {}", service, namespace);
-        DefaultKubernetesClient kubeClient = (DefaultKubernetesClient) getKubeClient();
-        String host = null;
-        Integer port = null;
-        Map<String, String> headers = null;
-        if (istionGatewayClusterIp != null) {
-            LOGGER.debug("Knative environment found, looking up for ingresgateway {} and host for serving service", istionGatewayClusterIp);
-            host = istionGatewayClusterIp;
-            port = 80;
-            headers = new HashMap<>();
-            
-            Request request = new Request.Builder().url(kubeClient.getMasterUrl() + KNATIVE_SERVICE_SERVICE_URL.replaceFirst("@ns@", namespace) + service)
-                                                   .build();
-            LOGGER.debug("About to call a search for services labeled with {}, complete url is {}", service, request.url());
-            try (Response response = kubeClient.getHttpClient().newCall(request).execute()) {
-                String out = response.body().string();
-                if (response.isSuccessful()) {
-                    Map<?, ?> data = mapper.readValue(out, Map.class);
-                    headers.put("HOST", ((Map<?, ?>)((Map<?, ?>)((List<?>)data.get("items")).get(0)).get("status")).get("domain").toString());
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            LOGGER.debug("Headers to be used for requests {}", headers);
-            
-        } else {
-            LOGGER.debug("Looking up for service in regular kube/openshift environment");
-            
-            Request request = new Request.Builder()
-                                                   .url(kubeClient.getMasterUrl() + SERVICE_URL.replaceFirst("@ns@", namespace) + service)
-                                                   .build();
-
-            try (Response response = kubeClient.getHttpClient().newCall(request).execute()) {
-                String out = response.body().string();
-
-                if (response.isSuccessful()) {
-                    Map<?, ?> data = mapper.readValue(out, Map.class);
-                    
-                    Map<?, ?> spec = ((Map<?, ?>) ((Map<?, ?>) ((List<?>) data.get("items")).get(0)).get("spec"));
-                    host = spec.get("clusterIP").toString();
-                    port = (Integer) ((Map<?, ?>) ((List<?>)spec.get("ports")).get(0)).get("port");
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }            
-        }
-        if (host == null) {
-          throw new RuntimeException("No endpoint found for service " + service);
-        }
-        StringBuilder location = new StringBuilder("http://")
-                .append(host)
-                .append(":")
-                .append(port)
-                .append("/")
-                .append(service);
-        LOGGER.debug("Host {} and port {} found for service {} in namespace {}", host, port, service, namespace);
-       return new ServiceInfo(location.toString(), headers);
+        return serviceDiscovery.findEndpoint(namespace, service).orElseThrow(() -> new RuntimeException("No endpoint found for service " + service));
     }
 
     /**
@@ -158,17 +111,17 @@ public abstract class DiscoveredServiceWorkItemHandler implements WorkItemHandle
     protected Map<String, Object> discoverAndCall(WorkItem workItem, String namespace, String serviceName, HttpMethods method) {
         Map<String, Object> data = new HashMap<>(workItem.getParameters());
         String service = (String) data.remove(serviceName);
-        
+
         // remove all internal fields before sending
         INTERNAL_FIELDS.forEach(field -> data.remove(field));
-        
+
         // discover service endpoint
         ServiceInfo endpoint = serviceEndpoints.computeIfAbsent(service, (s) -> findEndpoint(namespace, s));
         LOGGER.debug("Found endpoint for service {} with location {}", service, endpoint);
-        
+
         RequestBody body = produceRequestPayload(data);
         Request request = null;
-        
+
         switch (method) {
             case POST:
                 request = producePostRequest(endpoint, body);
@@ -187,16 +140,16 @@ public abstract class DiscoveredServiceWorkItemHandler implements WorkItemHandle
         }
 
         try (Response response = http.newCall(request).execute()) {
-            
+
             Map<String, Object> results = produceResultsFromResponse(response);
-            
+
             return results;
 
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
-    
+
     protected RequestBody produceRequestPayload(Map<String, Object> data) {
         if (data == null) {
             return null;
@@ -205,59 +158,59 @@ public abstract class DiscoveredServiceWorkItemHandler implements WorkItemHandle
             String json = mapper.writeValueAsString(data);
             LOGGER.debug("Sending body {}", json);
             RequestBody body = RequestBody.create(JSON, json);
-            
+
             return body;
         } catch (Exception e) {
             throw new RuntimeException("Unexpected error when producing request payload", e);
         }
     }
-    
+
     @SuppressWarnings("unchecked")
     protected Map<String, Object> produceResultsFromResponse(Response response) throws IOException {
-        String payload = response.body().string();            
+        String payload = response.body().string();
         LOGGER.debug("Resonse code {} and payload {}", response.code(), payload);
-        
+
         if (!response.isSuccessful()) {
             throw new RuntimeException("Unsuccessful response from service " + response.message() + " (code " + response.code() + ")");
         }
-        
+
         Map<String, Object> results = mapper.readValue(payload, Map.class);
-        
+
         return results;
     }
-    
+
     protected Request producePostRequest(ServiceInfo endpoint, RequestBody body) {
         Builder builder = new Request.Builder().url(endpoint.getUrl())
-                .post(body);
+                                               .post(body);
         applyHeaders(endpoint, builder);
-        
+
         return builder.build();
     }
-    
+
     protected Request produceGetRequest(ServiceInfo endpoint) {
         Builder builder = new Request.Builder().url(endpoint.getUrl())
-                .get();
+                                               .get();
         applyHeaders(endpoint, builder);
-        
+
         return builder.build();
     }
-    
+
     protected Request producePutRequest(ServiceInfo endpoint, RequestBody body) {
         Builder builder = new Request.Builder().url(endpoint.getUrl())
-                .put(body);
+                                               .put(body);
         applyHeaders(endpoint, builder);
-        
+
         return builder.build();
     }
-    
+
     protected Request produceDeleteRequest(ServiceInfo endpoint, RequestBody body) {
         Builder builder = new Request.Builder().url(endpoint.getUrl())
-                .delete(body);
+                                               .delete(body);
         applyHeaders(endpoint, builder);
-        
+
         return builder.build();
     }
-    
+
     protected void applyHeaders(ServiceInfo endpoint, Builder builder) {
 
         if (endpoint.getHeaders() != null) {
@@ -266,31 +219,5 @@ public abstract class DiscoveredServiceWorkItemHandler implements WorkItemHandle
             }
         }
     }
-    
-    protected KubernetesClient getKubeClient() {
-        if (client == null) {
-            synchronized (this) {
-                if (client == null) {
-                    client = new DefaultKubernetesClient();
-                    LOGGER.debug("Kube Client created, looking up istio ingressgateway...");
-                    Request request = new Request.Builder().url(client.getMasterUrl() + KNATIVE_ISTIO_GATEWAY_URL)
-                                                           .build();
 
-                    try (Response response = ((DefaultKubernetesClient) client).getHttpClient().newCall(request).execute()) {
-                        String out = response.body().string();
-                        LOGGER.debug("Request {} completed with code {}, and response {}", request.url().toString(), response.code(), out);
-                        if (response.isSuccessful()) {
-                            Map<?, ?> data = mapper.readValue(out, Map.class);
-                            this.istionGatewayClusterIp = ((Map<?, ?>) data.get("spec")).get("clusterIP").toString();
-                        }
-                        LOGGER.debug("Istio geteway is " + istionGatewayClusterIp);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-        return client;
-
-    }
 }

--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/BaseServiceDiscovery.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/BaseServiceDiscovery.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.workitems.service.discovery;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
+import org.kie.kogito.cloud.workitems.ServiceInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class BaseServiceDiscovery implements ServiceDiscovery {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(BaseServiceDiscovery.class);
+    static final String KEY_ITEMS = "items";
+    static final String KEY_SPEC = "spec";
+    static final String KEY_CLUSTER_IP = "clusterIP";
+    static final String DEFAULT_PROTOCOL = "http://";
+    static final int DEFAULT_PORT = 80;
+
+    protected KogitoKubeClient kubeClient;
+
+    public BaseServiceDiscovery(final KogitoKubeClient kubeClient) {
+        this.kubeClient = kubeClient;
+    }
+
+    /**
+     * Should implement the Services API query logic according to the infrastructure.   
+     * 
+     * @see {@link KubernetesServiceDiscovery} for reference
+     * @param namespace the namespace where to query the service from
+     * @param labelKey an optional label key specified by the service
+     * @param labelValue an optional label value specified by the service
+     * @return a list of <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#service-v1-core">Service specification</a> in a map structure based on the JSON server response
+     */
+    protected abstract List<Map<String, Object>> query(final String namespace, Map<String, String> labels);
+
+    /**
+     * Should build the {@link ServiceInfo} object based on the {@link #query(String, Map)} returned value.
+     * 
+     * @param services
+     * @return
+     */
+    protected abstract ServiceInfo buildService(final List<Map<String, Object>> services, final String service);
+
+    private Map<String, String> buildLabelMap(final String labelKey, final String labelValue) {
+        if (labelKey == null || labelKey.isEmpty()) {
+            return null;
+        } else {
+            return Collections.singletonMap(labelKey, labelValue);
+        }
+    }
+
+    public final Optional<ServiceInfo> findEndpoint(String namespace, String labelKey, String labelValue) {
+        LOGGER.debug("About to query for endpoints in namespace {} with labels {}:{}", namespace, labelKey, labelValue);
+        final List<Map<String, Object>> services = query(namespace, this.buildLabelMap(labelKey, labelValue));
+        LOGGER.debug("Result of services query: {}", services);
+
+        if (services.size() > 1) {
+            LOGGER.warn("Found more than one endpoint using labels {}:{}. Returning the first one in the list. Try to be more specific in the query search.",
+                        labelKey,
+                        labelValue);
+        } else if (services.isEmpty()) {
+            LOGGER.warn("Haven't found any endpoint in the namespace {} with labels {}:{}", namespace, labelKey, labelValue);
+            return Optional.empty();
+        }
+
+        return Optional.of(this.buildService(services, labelValue == null || labelValue.isEmpty() ? labelKey : labelValue));
+    }
+
+    public final Optional<ServiceInfo> findEndpoint(String namespace, String service) {
+        return this.findEndpoint(namespace, service, null);
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/IstioServiceDiscovery.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/IstioServiceDiscovery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.workitems.service.discovery;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
+import org.kie.kogito.cloud.kubernetes.client.operations.MapWalker;
+import org.kie.kogito.cloud.workitems.ServiceInfo;
+
+public class IstioServiceDiscovery extends BaseServiceDiscovery {
+
+    private static final String SERVICE_KEY_HOST = "HOST";
+    private static final String KEY_STATUS = "status";
+    /**
+     * Key field for service endpoint on KNative Serving 0.6.x and bellow
+     */
+    private static final String KEY_DOMAIN = "domain";
+    /**
+     * Key field for service endpoint on KNative Serving 0.7+
+     * 
+     * @see <a href="https://github.com/knative/serving/blob/master/docs/spec/spec.md#service">KNative Serving Service spec</a>
+     */
+    private static final String KEY_URL = "url";
+    private static final String PROTOCOL_REGEX = "^(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)";
+    private static final String SLASH_REGEX = "\\/$";
+
+    private final String istioGatewayUrl;
+
+    public IstioServiceDiscovery(final KogitoKubeClient kubeClient, final String istioGatewayUrl) {
+        super(kubeClient);
+        this.istioGatewayUrl = istioGatewayUrl;
+    }
+
+    @Override
+    protected List<Map<String, Object>> query(String namespace, Map<String, String> labels) {
+        return kubeClient.knativeService()
+                         .listNamespaced(namespace, labels)
+                         .asMapWalker()
+                         .mapToListMap(KEY_ITEMS)
+                         .asList();
+    }
+
+    @Override
+    protected ServiceInfo buildService(List<Map<String, Object>> services, final String service) {
+        final Map<String, String> headers = new HashMap<>();
+        final Map<String, Object> response = new MapWalker(services.get(0)).mapToMap(KEY_STATUS).asMap();
+        String endpoint = "";
+        if (response.containsKey(KEY_URL)) {
+            endpoint = response.get(KEY_URL).toString().replaceAll(PROTOCOL_REGEX, "").replaceAll(PROTOCOL_REGEX, "");
+            LOGGER.debug("Found key {} using endpoint: {}", KEY_URL, endpoint);
+        } else {
+            endpoint = response.get(KEY_DOMAIN).toString();
+            LOGGER.debug("Found key {} using endpoint: {}", KEY_DOMAIN, endpoint);
+        }
+        headers.put(SERVICE_KEY_HOST, endpoint);
+        LOGGER.debug("Headers to be used for requests {}", headers);
+        return new ServiceInfo(String.format("%s%s", this.istioGatewayUrl, service), headers);
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/KubernetesServiceDiscovery.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/KubernetesServiceDiscovery.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.workitems.service.discovery;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
+import org.kie.kogito.cloud.kubernetes.client.operations.MapWalker;
+import org.kie.kogito.cloud.workitems.ServiceInfo;
+
+public class KubernetesServiceDiscovery extends BaseServiceDiscovery {
+
+    private static final String KEY_PORTS = "ports";
+    private static final String KEY_PORT = "port";
+
+    public KubernetesServiceDiscovery(final KogitoKubeClient kubeClient) {
+        super(kubeClient);
+    }
+
+    @Override
+    protected List<Map<String, Object>> query(String namespace, Map<String, String> labels) {
+        return kubeClient.services()
+                         .listNamespaced(namespace, labels)
+                         .asMapWalker()
+                         .mapToListMap(KEY_ITEMS)
+                         .asList();
+    }
+
+    @Override
+    protected ServiceInfo buildService(List<Map<String, Object>> services, String service) {
+        final StringBuilder url = new StringBuilder();
+        url
+           .append(DEFAULT_PROTOCOL)
+           .append(new MapWalker(services.get(0)).mapToMap(KEY_SPEC).asMap().get(KEY_CLUSTER_IP))
+           .append(":")
+           .append(new MapWalker(services.get(0)).mapToMap(KEY_SPEC)
+                                                 .mapToListMap(KEY_PORTS)
+                                                 .listToMap(0)
+                                                 .asMap().get(KEY_PORT))
+           .append("/")
+           .append(service);
+
+        return new ServiceInfo(url.toString(), new HashMap<>());
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/ServiceDiscovery.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/ServiceDiscovery.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.workitems.service.discovery;
+
+import java.util.Optional;
+
+import org.kie.kogito.cloud.workitems.ServiceInfo;
+
+/**
+ * Service Discovery mechanism: tries to discover the desired endpoint based on the cluster infrastructure: Kubernetes, OpenShift, Istio/KNative or Operators. 
+ */
+public interface ServiceDiscovery {
+
+    /**
+     * Finds an endpoint based on a namespace and the specified label. 
+     * If more than one service is found, the first one is returned.  
+     * The service must reside within the namespace. 
+     * 
+     * @param namespace the namespace where to look for the namespace. Can't be null.
+     * @param labelKey optional label key.
+     * @param labelValue optional label value. Ignored if key is empty.
+     * @return
+     */
+    public Optional<ServiceInfo> findEndpoint(final String namespace, final String labelKey, final String labelValue);
+
+    /**
+     * Finds an endpoint based on a namespace with a label key equals to the name of the service. 
+     * If more than one service is found, the first one is returned. 
+     * The service must reside within the namespace.   
+     * 
+     * @param namespace the namespace where to look for the namespace. Can't be null.
+     * @param service the service name that should match with any label in the Kubernetes Service.    
+     * @return
+     */
+    public Optional<ServiceInfo> findEndpoint(final String namespace, final String service);
+
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/ServiceDiscoveryFactory.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/ServiceDiscoveryFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.workitems.service.discovery;
+
+import org.kie.kogito.cloud.kubernetes.client.DefaultKogitoKubeClient;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ServiceDiscoveryFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceDiscoveryFactory.class);
+
+    private static ServiceDiscoveryFactory factory;
+    private KogitoKubeClient kubeClient;
+    private boolean istioEnv;
+    private String istioGatewayUrl;
+
+    private ServiceDiscoveryFactory(final KogitoKubeClient kubeClient) {
+        this.kubeClient = kubeClient;
+        this.discoverIstioGatewayUrl();
+    }
+
+    public static ServiceDiscovery build() {
+        return build(new DefaultKogitoKubeClient());
+    }
+
+    public static ServiceDiscovery build(final KogitoKubeClient kubeClient) {
+        factory = new ServiceDiscoveryFactory(kubeClient);
+        if (factory.isIstioEnv()) {
+            return new IstioServiceDiscovery(kubeClient, factory.getIstioGatewayUrl());
+        } else {
+            return new KubernetesServiceDiscovery(kubeClient);
+        }
+    }
+
+    public boolean isIstioEnv() {
+        return istioEnv;
+    }
+
+    public String getIstioGatewayUrl() {
+        return istioGatewayUrl;
+    }
+
+    private void discoverIstioGatewayUrl() {
+        LOGGER.debug("Trying to discover Istio Gateway URL");
+        try {
+            final String clusterIp =
+                    (String) kubeClient.istioGateway()
+                                       .get()
+                                       .asMapWalker(true)
+                                       .mapToMap(BaseServiceDiscovery.KEY_SPEC)
+                                       .asMap()
+                                       .get(BaseServiceDiscovery.KEY_CLUSTER_IP);
+            if (clusterIp == null || clusterIp.isEmpty()) {
+                LOGGER.info("Not in Istio environment");
+                this.istioEnv = false;
+                this.istioGatewayUrl = null;
+            } else {
+                this.istioEnv = true;
+                this.istioGatewayUrl =
+                        new StringBuilder()
+                                           .append(BaseServiceDiscovery.DEFAULT_PROTOCOL)
+                                           .append(clusterIp)
+                                           .append(":")
+                                           .append(BaseServiceDiscovery.DEFAULT_PORT)
+                                           .append("/")
+                                           .toString();
+                LOGGER.info("Discovered Istio Gateway URL {}. Will use Istio as default service discovery mechanism", this.istioGatewayUrl);
+            }
+        } catch (Exception ex) {
+            this.istioEnv = false;
+            this.istioGatewayUrl = null;
+            LOGGER.warn("Failed to look up for Istio Gateway URL: '{}'. Enable debug logging to view the full stack trace. Failing back to standard Service API.", ex.getMessage());
+            LOGGER.debug("Error while trying to fetch for Istio Gateway URL", ex);
+        }
+    }
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseKubernetesDiscoveredServiceTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseKubernetesDiscoveredServiceTest.java
@@ -15,12 +15,16 @@
 
 package org.kie.kogito.cloud.workitems;
 
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.junit.After;
 import org.junit.Before;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.kogito.cloud.kubernetes.client.DefaultKogitoKubeClient;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeConfig;
 
 /**
  * Base class for tests with Kubernetes API. In this scenario, nor Istio or KNative is available.
@@ -31,10 +35,24 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
 
     public static final String MOCK_NAMESPACE = "mock-namespace";
 
+    private boolean enableIstio;
+    private boolean istioEnabled;
+
+    public BaseKubernetesDiscoveredServiceTest() {
+        this.enableIstio = false;
+    }
+
+    public BaseKubernetesDiscoveredServiceTest(final boolean enableIstio) {
+        this.enableIstio = enableIstio;
+    }
+
     // will be changed to junit5 extensions once migrated
     @Before
     public void before() {
         server.before();
+        if (this.enableIstio) {
+            this.createsIstioIngressGateway();
+        }
     }
 
     // will be changed to junit5 extensions once migrated
@@ -43,18 +61,33 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
         server.after();
     }
 
-    protected KubernetesClient getClient() {
+    public boolean isIstioEnabled() {
+        return istioEnabled;
+    }
 
+    protected KubernetesClient getClient() {
         return server.getClient().inNamespace(MOCK_NAMESPACE);
+    }
+
+    /**
+     * Enables Istio in the test environment.
+     */
+    private void createsIstioIngressGateway() {
+        final ServiceResource<Service, ?> serviceResource =
+                this.server.getClient()
+                           .inNamespace(KogitoKubeConfig.KNATIVE_ISTIO_NAMESPACE)
+                           .services()
+                           .load(this.getClass().getResource("/mock/responses/ocp4.x/istio/services-istio-ingressgateway.json"));
+        this.server.getClient()
+                   .inNamespace(KogitoKubeConfig.KNATIVE_ISTIO_NAMESPACE)
+                   .services().create(serviceResource.get());
+        this.istioEnabled = true;
     }
 
     protected static class TestDiscoveredServiceWorkItemHandler extends DiscoveredServiceWorkItemHandler {
 
-        private final BaseKubernetesDiscoveredServiceTest testCase;
-
         public TestDiscoveredServiceWorkItemHandler(BaseKubernetesDiscoveredServiceTest testCase) {
-            super();
-            this.testCase = testCase;
+            super(new DefaultKogitoKubeClient().withConfig(new KogitoKubeConfig(testCase.getClient())));
         }
 
         @Override
@@ -62,12 +95,6 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
 
         @Override
         public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {}
-
-        @Override
-        protected KubernetesClient getKubeClient() {
-            this.istionGatewayClusterIp = null;
-            return this.testCase.getClient();
-        }
 
     }
 

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
@@ -15,18 +15,9 @@
 
 package org.kie.kogito.cloud.workitems;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.kie.api.runtime.process.WorkItem;
-import org.kie.api.runtime.process.WorkItemManager;
-import org.mockito.Mockito;
 
 import okhttp3.Call;
 import okhttp3.MediaType;
@@ -37,6 +28,18 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
+import org.kie.kogito.cloud.workitems.service.discovery.ServiceDiscovery;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DiscoveredServiceWorkItemHandlerTest {
     
@@ -106,5 +109,9 @@ public class DiscoveredServiceWorkItemHandlerTest {
             return httpClient;
         }
         
+        @Override
+        protected ServiceDiscovery buildServiceDiscovery(KogitoKubeClient kubeClient) {
+            return mock(ServiceDiscovery.class);
+        }
     }
 }

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KNativeDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KNativeDiscoveredServiceWorkItemHandlerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.kogito.cloud.workitems;
+
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class KNativeDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesDiscoveredServiceTest {
+
+    public KNativeDiscoveredServiceWorkItemHandlerTest() {
+        super(true);
+    }
+
+    @Test
+    public void whenExistsAServiceWithKNative() {
+        final RecreateFromServerGettable<KubernetesList, KubernetesList, ?> serviceResource =
+                this.getClient().lists().load(this.getClass().getResource("/mock/responses/ocp4.x/knative/serving.knative.dev-services.json"));
+        this.getClient().lists().create(serviceResource.get());
+
+        final DiscoveredServiceWorkItemHandler handler = new TestDiscoveredServiceWorkItemHandler(this);
+        final ServiceInfo serviceInfo = handler.findEndpoint(MOCK_NAMESPACE, "employeeValidation");
+        assertThat(serviceInfo, notNullValue());
+        assertThat(serviceInfo.getUrl(), is("http://172.30.101.218:80/employeeValidation"));
+        assertThat(serviceInfo.getHeaders().get("HOST"), is("onboarding-hr.test.apps.example.com"));
+    }
+
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/resources/logback-test.xml
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/resources/mock/responses/ocp4.x/istio/services-istio-ingressgateway.json
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/resources/mock/responses/ocp4.x/istio/services-istio-ingressgateway.json
@@ -1,0 +1,112 @@
+{
+	"kind": "Service",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "istio-ingressgateway",
+		"namespace": "istio-system",
+		"labels": {
+			"app": "istio-ingressgateway",
+			"chart": "gateways",
+			"heritage": "Tiller",
+			"istio": "ingressgateway",
+			"maistra-version": "0.10.0",
+			"release": "istio"
+		},
+		"ownerReferences": [
+			{
+				"apiVersion": "istio.openshift.com/v1alpha3",
+				"kind": "ControlPlane",
+				"name": "minimal-istio",
+				"uid": "be2b0fc2-a7d9-11e9-b86c-02ff077e3f52",
+				"controller": true,
+				"blockOwnerDeletion": true
+			}
+		]
+	},
+	"spec": {
+		"ports": [
+			{
+				"name": "http2",
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 80,
+				"nodePort": 31380
+			},
+			{
+				"name": "https",
+				"protocol": "TCP",
+				"port": 443,
+				"targetPort": 443,
+				"nodePort": 31390
+			},
+			{
+				"name": "tcp",
+				"protocol": "TCP",
+				"port": 31400,
+				"targetPort": 31400,
+				"nodePort": 31400
+			},
+			{
+				"name": "https-kiali",
+				"protocol": "TCP",
+				"port": 15029,
+				"targetPort": 15029,
+				"nodePort": 31184
+			},
+			{
+				"name": "https-prometheus",
+				"protocol": "TCP",
+				"port": 15030,
+				"targetPort": 15030,
+				"nodePort": 32448
+			},
+			{
+				"name": "https-grafana",
+				"protocol": "TCP",
+				"port": 15031,
+				"targetPort": 15031,
+				"nodePort": 32364
+			},
+			{
+				"name": "https-tracing",
+				"protocol": "TCP",
+				"port": 15032,
+				"targetPort": 15032,
+				"nodePort": 32760
+			},
+			{
+				"name": "tls",
+				"protocol": "TCP",
+				"port": 15443,
+				"targetPort": 15443,
+				"nodePort": 31520
+			},
+			{
+				"name": "status-port",
+				"protocol": "TCP",
+				"port": 15020,
+				"targetPort": 15020,
+				"nodePort": 31358
+			}
+		],
+		"selector": {
+			"app": "istio-ingressgateway",
+			"istio": "ingressgateway",
+			"maistra-version": "0.10.0",
+			"release": "istio"
+		},
+		"clusterIP": "172.30.101.218",
+		"type": "LoadBalancer",
+		"sessionAffinity": "None",
+		"externalTrafficPolicy": "Cluster"
+	},
+	"status": {
+		"loadBalancer": {
+			"ingress": [
+				{
+					"hostname": "example.com"
+				}
+			]
+		}
+	}
+}

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/resources/mock/responses/ocp4.x/knative/serving.knative.dev-services.json
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/resources/mock/responses/ocp4.x/knative/serving.knative.dev-services.json
@@ -1,0 +1,91 @@
+{
+	"apiVersion": "serving.knative.dev/v1alpha1",
+	"kind": "ServiceList",
+	"metadata": {
+		"continue": ""
+	},
+	"items": [
+		{
+			"apiVersion": "serving.knative.dev/v1alpha1",
+			"kind": "Service",
+			"metadata": {
+				"annotations": {
+					"serving.knative.dev/creator": "kube:admin",
+					"serving.knative.dev/lastModifier": "kube:admin"
+				},
+				"labels": {
+					"department": "process",
+					"employeeValidation": "process",
+					"id": "process"
+				},
+				"name": "onboarding-hr",
+				"uid": "3c62c345-a8bd-11e9-83df-02ff077e3f52"
+			},
+			"spec": {
+				"template": {
+					"spec": {
+						"containers": [
+							{
+								"env": [
+									{
+										"name": "NAMESPACE",
+										"value": "test"
+									}
+								],
+								"image": "docker.io/mswiderski/onboarding-hr:0.1",
+								"name": "user-container",
+								"resources": {
+									"limits": {
+										"cpu": "1",
+										"memory": "200M"
+									},
+									"requests": {
+										"cpu": "400m",
+										"memory": "100M"
+									}
+								}
+							}
+						],
+						"timeoutSeconds": 300
+					}
+				},
+				"traffic": [
+					{
+						"latestRevision": true,
+						"percent": 100
+					}
+				]
+			},
+			"status": {
+				"address": {
+					"url": "http://onboarding-hr.test.svc.cluster.local"
+				},
+				"conditions": [
+					{
+						"status": "True",
+						"type": "ConfigurationsReady"
+					},
+					{
+						"status": "True",
+						"type": "Ready"
+					},
+					{
+						"status": "True",
+						"type": "RoutesReady"
+					}
+				],
+				"latestCreatedRevisionName": "onboarding-hr-zgjk8",
+				"latestReadyRevisionName": "onboarding-hr-zgjk8",
+				"observedGeneration": 1,
+				"traffic": [
+					{
+						"latestRevision": true,
+						"percent": 100,
+						"revisionName": "onboarding-hr-zgjk8"
+					}
+				],
+				"url": "http://onboarding-hr.test.apps.example.com"
+			}
+		}
+	]
+}

--- a/kogito-cloud-services/pom.xml
+++ b/kogito-cloud-services/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.kie.kogito</groupId>
@@ -12,6 +14,7 @@
 
   <modules>
     <module>kogito-cloud-workitems</module>
+    <module>kogito-cloud-kubernetes-client</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/JBPM-8549

This PR is meant to add a kubernetes client module that doesn't rely on reflection to parse JSON responses, but at the same time uses Fabric8 Kube client as an alternative to perform authentication and configuration of the client within a OpenShift/Kube cluster.

It's meant to be simple to tackle the Kogito Cloud use cases, like service discovery.

Tested against JDK8, JDK11, GraalVM and native images on docker containers and an OpenShift 3.11 cluster.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>