### PR TITLE
[JBPM-8624] - Removing EC Keys support from Kubernetes Client

### DIFF
--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/pom.xml
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/pom.xml
@@ -25,6 +25,11 @@
       <artifactId>kubernetes-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.oracle.substratevm</groupId>
+      <artifactId>svm</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/graal/KubernetesClientCertUtilsSubstitutions.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/main/java/org/kie/kogito/cloud/kubernetes/client/graal/KubernetesClientCertUtilsSubstitutions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.kogito.cloud.kubernetes.client.graal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivateKey;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+/**
+ * Removes EC Keys support from Fabric8 Kubernetes client dependency on native binaries. 
+ * This avoids clients to add <code>--allow-incomplete-classpath</code> option on their build configuration.
+ * <p/>
+ * Cloned from <a href="https://github.com/quarkusio/quarkus/blob/master/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/graal/CertUtilsSubstitutions.java">Quarkus Kubernetes Extension</a> to not add Quarkus dependencies to this project
+ */
+@TargetClass(className = "io.fabric8.kubernetes.client.internal.CertUtils")
+public final class KubernetesClientCertUtilsSubstitutions {
+
+    @Substitute
+    static PrivateKey handleECKey(InputStream keyInputStream) throws IOException {
+        throw new RuntimeException("EC Keys are not supported when using the native binary");
+    }
+
+}


### PR DESCRIPTION
See: https://issues.jboss.org/browse/JBPM-8624

After upgrading to Fabric8 Kubernetes Client 4.3.x, native image compilation would throw an exception regarding EC Keys handling with BouncyCastle dependency. This implementation was cut from the [Quarkus Kubernetes Exception](https://github.com/quarkusio/quarkus/blob/master/extensions/kubernetes-client/runtime/src/main/java/io/quarkus/kubernetes/client/runtime/graal/CertUtilsSubstitutions.java) with this same problem. 

This PR adds a dependency on Oracle Substrate library and a feature to replace the BouncyCastle dependency to the Kogito Kube Client.

Another alternatives to remedy this problem:

1. Add the Quarkus Kubernetes Extension with runtime scope. Non-Quarkus clients (like SpringBoot) will bring unneeded dependencies
2. Update the library docs to recommend users to add `-allow-incomplete-classpath` or `--initialize-at-run-time=io.fabric8.kubernetes.client.internal.CertUtils` to their native builds

I opt to remove the BouncyCastle dependency transparently by adding the Oracle Substrate lib (as provided) to increase ease of use of this library.