### PR TITLE
[KOGITO-7] Migrating to JUnit 5

### DIFF
--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/pom.xml
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/pom.xml
@@ -30,8 +30,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/KubeClientConfigTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/KubeClientConfigTest.java
@@ -19,9 +19,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -32,17 +32,17 @@ public class KubeClientConfigTest {
     public static final Path KUBE_CONFIG_PATH = Paths.get(System.getProperty("user.home") + "/.kube/config");
     public static final Path KUBE_CONFIG_DIR = Paths.get(System.getProperty("user.home") + "/.kube");
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException {
         if (!Files.exists(KUBE_CONFIG_PATH)) {
-            if(!Files.exists(KUBE_CONFIG_DIR)) {
+            if (!Files.exists(KUBE_CONFIG_DIR)) {
                 Files.createDirectories(KUBE_CONFIG_DIR);
             }
             Files.createFile(KUBE_CONFIG_PATH);
         }
     }
 
-    @After
+    @AfterEach
     public void teardown() throws IOException {
         if (Files.exists(KUBE_CONFIG_PATH) && Files.readAllBytes(KUBE_CONFIG_PATH).length == 0) {
             Files.delete(KUBE_CONFIG_PATH);

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/MockKubernetesServerSupport.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/MockKubernetesServerSupport.java
@@ -29,8 +29,8 @@ import io.fabric8.kubernetes.api.model.ServiceStatus;
 import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Base class to test use cases that need to query the API
@@ -64,13 +64,13 @@ public abstract class MockKubernetesServerSupport {
         this.server = new KubernetesServer(false, crudMode);
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         server.before();
         this.kubeClient = new DefaultKogitoKubeClient().withConfig(new KogitoKubeConfig(server.getClient()));
     }
 
-    @After
+    @AfterEach
     public void after() {
         server.after();
     }

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/MapWalkerTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/MapWalkerTest.java
@@ -16,11 +16,11 @@ package org.kie.kogito.cloud.kubernetes.client.operations;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MapWalkerTest {
 
@@ -33,12 +33,11 @@ public class MapWalkerTest {
         final MapWalker walker = new MapWalker(new HashMap<>(), true);
         assertThat(walker.mapToListMap("test").listToMap(0).asMap(), notNullValue());
     }
-    
-    @Test(expected = IllegalArgumentException.class)
+
+    @Test
     public void whenMapIsEmptyAndIsNotSafe() {
         final MapWalker walker = new MapWalker(new HashMap<>());
-       walker.mapToListMap("test").listToMap(0).asMap();
-       fail("Should explode an exception while is not safe walking through an empty map");
+        assertThrows(IllegalArgumentException.class, () -> walker.mapToListMap("test").listToMap(0).asMap());
     }
 
 }

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsStatusCodeHandlingTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsStatusCodeHandlingTest.java
@@ -17,7 +17,7 @@ package org.kie.kogito.cloud.kubernetes.client.operations;
 import java.net.HttpURLConnection;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClientException;
 import org.kie.kogito.cloud.kubernetes.client.MockKubernetesServerSupport;
 
@@ -25,10 +25,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Test cases where
+ * Service Operations test cases that integrates with a mock Kubernetes server to validate HTTP Rest API handling.
  */
 public class ServiceOperationsStatusCodeHandlingTest extends MockKubernetesServerSupport {
 
@@ -66,9 +67,9 @@ public class ServiceOperationsStatusCodeHandlingTest extends MockKubernetesServe
         }
     }
 
-    @Test(expected = KogitoKubeClientException.class)
+    @Test
     public void whenServerError() {
         getServer().expect().get().withPath("/api/v1/services").andReturn(HttpURLConnection.HTTP_BAD_GATEWAY, null).once();
-        this.getKubeClient().services().list(null).asMap();
+        assertThrows(KogitoKubeClientException.class, () -> this.getKubeClient().services().list(null).asMap());
     }
 }

--- a/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsTest.java
+++ b/kogito-cloud-services/kogito-cloud-kubernetes-client/src/test/java/org/kie/kogito/cloud/kubernetes/client/operations/ServiceOperationsTest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.kie.kogito.cloud.kubernetes.client.MockKubernetesServerSupport;
 
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/kogito-cloud-services/kogito-cloud-workitems/pom.xml
+++ b/kogito-cloud-services/kogito-cloud-workitems/pom.xml
@@ -26,8 +26,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseKubernetesDiscoveredServiceTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/BaseKubernetesDiscoveredServiceTest.java
@@ -19,8 +19,8 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ServiceResource;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.kogito.cloud.kubernetes.client.DefaultKogitoKubeClient;
@@ -46,8 +46,7 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
         this.enableIstio = enableIstio;
     }
 
-    // will be changed to junit5 extensions once migrated
-    @Before
+    @BeforeEach
     public void before() {
         server.before();
         if (this.enableIstio) {
@@ -55,8 +54,7 @@ public abstract class BaseKubernetesDiscoveredServiceTest {
         }
     }
 
-    // will be changed to junit5 extensions once migrated
-    @After
+    @AfterEach
     public void after() {
         server.after();
     }

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
@@ -28,8 +28,8 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Buffer;
 import okio.BufferedSource;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.kogito.cloud.kubernetes.client.KogitoKubeClient;
@@ -46,7 +46,7 @@ public class DiscoveredServiceWorkItemHandlerTest {
     
     private OkHttpClient httpClient;
 
-    @Before
+    @BeforeEach
     public void setup() {
         httpClient = mock(OkHttpClient.class);
     }

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KNativeDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KNativeDiscoveredServiceWorkItemHandlerTest.java
@@ -17,11 +17,11 @@ package org.kie.kogito.cloud.workitems;
 
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KNativeDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesDiscoveredServiceTest {
 

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
@@ -25,13 +25,14 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
 import io.fabric8.kubernetes.api.model.ServiceStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
 
 public class KubernetesDiscoveredServiceWorkItemHandlerTest extends BaseKubernetesDiscoveredServiceTest {
 


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-7

Although Kubernetes Mock Server (from Fabric8) relies a lot from Junit 4, we can safely migrate our test cases to JUnit 5, since they can co-exist, from [JUnit 5 documentation](https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4):

> Since all classes and annotations specific to JUnit Jupiter reside under a new org.junit.jupiter base package, having both JUnit 4 and JUnit Jupiter in the classpath does not lead to any conflicts. It is therefore safe to maintain existing JUnit 4 tests alongside JUnit Jupiter tests. Furthermore, since the JUnit team will continue to provide maintenance and bug fix releases for the JUnit 4.x baseline, developers have plenty of time to migrate to JUnit Jupiter on their own schedule.

Also, [there's an issue opened in the Kubernetes Client](https://github.com/fabric8io/kubernetes-client/issues/1331) repository to handle this migration there as well.

All tests passed in the IDE and on maven command line.