### PR TITLE
[KOGITO-109][KOGITO-91] - Removing static initializations to okhttp3 …

### DIFF
--- a/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/IstioServiceDiscovery.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/main/java/org/kie/kogito/cloud/workitems/service/discovery/IstioServiceDiscovery.java
@@ -37,7 +37,6 @@ public class IstioServiceDiscovery extends BaseServiceDiscovery {
      */
     private static final String KEY_URL = "url";
     private static final String PROTOCOL_REGEX = "^(http:\\/\\/www\\.|https:\\/\\/www\\.|http:\\/\\/|https:\\/\\/)";
-    private static final String SLASH_REGEX = "\\/$";
 
     private final String istioGatewayUrl;
 

--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/DiscoveredServiceWorkItemHandlerTest.java
@@ -93,7 +93,7 @@ public class DiscoveredServiceWorkItemHandlerTest {
 
         public TestDiscoveredServiceWorkItemHandler(String service, String endpoint) {
             super();
-            this.serviceEndpoints.put(service, new ServiceInfo(endpoint, null));
+            this.addServices(service, new ServiceInfo(endpoint, null));
         }
         
         @Override


### PR DESCRIPTION
…and WARN msgs

See:
https://issues.jboss.org/browse/KOGITO-109
https://issues.jboss.org/browse/KOGITO-91

Also removed the WARN messages regarding fetching the Kube api. Now it's able to see them at DEBUG level, e.g.: `-e quarkus.log.level=DEBUG`