### PR TITLE
[KOGITO-222] - Export Infinispan authentication options

### DIFF
--- a/s2i/kogito-data-index-overrides.yaml
+++ b/s2i/kogito-data-index-overrides.yaml
@@ -13,6 +13,23 @@ labels:
 - name: "io.openshift.expose-services"
   value: "8180:http"
 
+envs:
+- name: "INFINISPAN_USEAUTH"
+  value: "false"
+  description: "Flag that signals to Infinispan Hotrod client to use authentication (Used to set the infinispan.client.hotrod.use_auth system property)"
+- name: "INFINISPAN_USERNAME"
+  value: ""
+  description: "Username for the user credential used by the Hotrod client (Used to set the infinispan.client.hotrod.auth_username system property)"
+- name: "INFINISPAN_PASSWORD"
+  value: ""
+  description: "Password for the user credential used by the Hotrod client (Used to set the infinispan.client.hotrod.auth_password system property)"
+- name: "INFINISPAN_AUTHREALM"
+  value: ""
+  description: "Infinispan authentication realm (Used to set the infinispan.client.hotrod.auth_realm system property)"
+- name: "INFINISPAN_SASLMECHANISM"
+  value: ""
+  description: "Sasl mechanism to use during authentication. Example: PLAIN (Used to set the infinispan.client.hotrod.sasl_mechanism system property)"
+
 ports:
 - value: 8180
 

--- a/s2i/modules/kogito-data-index/added/start
+++ b/s2i/modules/kogito-data-index/added/start
@@ -1,3 +1,38 @@
 #!/bin/bash -e
 
-java -Dquarkus.http.host=0.0.0.0 -Djava.library.path=$KOGITO_HOME/bin -jar $KOGITO_HOME/bin/*-runner.jar
+function set_infinispan_props() {
+    local infinispan_props=""
+
+    if [[ "${INFINISPAN_USEAUTH}" == "true" &&  -z "${INFINISPAN_USERNAME}" ]]; then
+        echo "[ERROR] Flag INFINISPAN_USEAUTH set to true, but no username informed. Please use INFINISPAN_USERNAME and INFINISPAN_PASSWORD variables to set the right credentials."
+        exit 1
+    fi
+
+    if [ -z "${INFINISPAN_USERNAME}" ]; then
+        if [ ! -z "${INFINISPAN_USEAUTH}" ]; then
+            INFINISPAN_USEAUTH="false"
+        fi
+    fi
+ 
+    if [ ! -z "${INFINISPAN_USERNAME}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_username=${INFINISPAN_USERNAME}"); INFINISPAN_USEAUTH="true"; fi
+    if [ ! -z "${INFINISPAN_PASSWORD}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_password=${INFINISPAN_PASSWORD}"); fi
+    if [ ! -z "${INFINISPAN_USEAUTH}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_useauth=${INFINISPAN_USEAUTH}"); fi
+    if [ ! -z "${INFINISPAN_AUTHREALM}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_authrealm=${INFINISPAN_AUTHREALM}"); fi
+    if [ ! -z "${INFINISPAN_SASLMECHANISM}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_saslmechanism=${INFINISPAN_SASLMECHANISM}"); fi
+
+    echo $infinispan_props
+}
+
+function start() {
+    local infinispan_props=$(set_infinispan_props)
+
+    java -Djava.library.path=$KOGITO_HOME/lib \
+        -Dquarkus.http.host=0.0.0.0 \
+        ${infinispan_props} \
+        ${JAVA_OPTS} \
+        -jar $KOGITO_HOME/bin/*-runner.jar
+}
+
+if [ -z "${TEST}" ]; then
+    start
+fi

--- a/s2i/modules/kogito-data-index/tests/bats/start.bats
+++ b/s2i/modules/kogito-data-index/tests/bats/start.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+
+export TEST=true
+
+# import
+load $BATS_TEST_DIRNAME/../../added/start
+
+function clear_vars() {
+    unset INFINISPAN_USEAUTH
+    unset INFINISPAN_USERNAME
+    unset INFINISPAN_PASSWORD
+    unset INFINISPAN_AUTHREALM
+    unset INFINISPAN_SASLMECHANISM
+}
+
+@test "check if infinispan properties is blank" {
+    clear_vars
+    local expected=""
+    run set_infinispan_props
+    
+    echo "Result is ${output} and expected is ${expected}" >&2
+    [ "${expected}" = "${output}" ]
+}
+
+
+@test "check if infinispan auth is false" {
+    clear_vars
+    export INFINISPAN_USEAUTH="false"
+    local expected="-Dinfinispan_useauth=false"
+    run set_infinispan_props
+    
+    echo "Result is ${output} and expected is ${expected}" >&2
+    [ "${expected}" = "${output}" ]
+}
+
+@test "check if infinispan has auth props" {
+    clear_vars
+    export INFINISPAN_USERNAME="developer"
+    export INFINISPAN_USEAUTH="true"
+    export INFINISPAN_PASSWORD="developer"
+    export INFINISPAN_AUTHREALM="default"
+    export INFINISPAN_SASLMECHANISM="PLAIN"
+    
+    local expected="-Dinfinispan_username=developer -Dinfinispan_password=developer -Dinfinispan_useauth=true -Dinfinispan_authrealm=default -Dinfinispan_saslmechanism=PLAIN"
+    run set_infinispan_props
+    
+    echo "Result is ${output} and expected is ${expected}" >&2
+    [ "${expected}" = "${output}" ]
+}
+
+@test "setting username, useauth is true" {
+    clear_vars
+    export INFINISPAN_USERNAME="developer"
+    export INFINISPAN_USEAUTH="false"
+    local expected="-Dinfinispan_username=developer -Dinfinispan_useauth=true"
+
+    run set_infinispan_props
+    
+    echo "Result is ${output} and expected is ${expected}" >&2
+    [ "${expected}" = "${output}" ]
+}
+
+@test "when use auth is set to nonsense and no credentials" {
+    clear_vars
+    export INFINISPAN_USEAUTH="dsadsadasdsa"
+    local expected="-Dinfinispan_useauth=false"
+
+    run set_infinispan_props
+    
+    echo "Result is ${output} and expected is ${expected}" >&2
+    [ "${expected}" = "${output}" ]
+}
+
+@test "when use auth is set to nonsense and has credentials" {
+    clear_vars
+    export INFINISPAN_USEAUTH="dsadsadasdsa"
+    export INFINISPAN_USERNAME="developer"
+    local expected="-Dinfinispan_username=developer -Dinfinispan_useauth=true"
+
+    run set_infinispan_props
+    
+    echo "Result is ${output} and expected is ${expected}" >&2
+    [ "${expected}" = "${output}" ]
+}
+
+@test "when use auth is set to true and no credentials" {
+    clear_vars
+    export INFINISPAN_USEAUTH="true"
+    local expected="-Dinfinispan_username=developer -Dinfinispan_useauth=true"
+
+    run set_infinispan_props
+    # exit(1)
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-222

Related PR:
https://github.com/kiegroup/kogito-runtimes/pull/142

In this PR we introduce a way to have infinispan authentication system properties imported via env vars. These vars will be set by the Kogito Operator.

Working image for tests:

```
quay.io/ricardozanini/kogito-data-index:latest
```

Includes both PRs.