### PR TITLE
[KOGITO-309] Using quarkus infinispan extension to set credentials to data index client

### DIFF
--- a/s2i/modules/kogito-data-index/added/start
+++ b/s2i/modules/kogito-data-index/added/start
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+# see https://quarkus.io/guides/infinispan-client-guide#quarkus-infinispan-client_configuration
 function set_infinispan_props() {
     local infinispan_props=""
 
@@ -14,11 +15,11 @@ function set_infinispan_props() {
         fi
     fi
  
-    if [ ! -z "${INFINISPAN_USERNAME}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_username=${INFINISPAN_USERNAME}"); INFINISPAN_USEAUTH="true"; fi
-    if [ ! -z "${INFINISPAN_PASSWORD}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_password=${INFINISPAN_PASSWORD}"); fi
-    if [ ! -z "${INFINISPAN_USEAUTH}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_useauth=${INFINISPAN_USEAUTH}"); fi
-    if [ ! -z "${INFINISPAN_AUTHREALM}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_authrealm=${INFINISPAN_AUTHREALM}"); fi
-    if [ ! -z "${INFINISPAN_SASLMECHANISM}" ]; then infinispan_props=$(echo "${infinispan_props} -Dinfinispan_saslmechanism=${INFINISPAN_SASLMECHANISM}"); fi
+    if [ ! -z "${INFINISPAN_USERNAME}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.auth-username=${INFINISPAN_USERNAME}"); INFINISPAN_USEAUTH="true"; fi
+    if [ ! -z "${INFINISPAN_PASSWORD}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.auth-password=${INFINISPAN_PASSWORD}"); fi
+    if [ ! -z "${INFINISPAN_USEAUTH}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.use-auth=${INFINISPAN_USEAUTH}"); fi
+    if [ ! -z "${INFINISPAN_AUTHREALM}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.auth-realm=${INFINISPAN_AUTHREALM}"); fi
+    if [ ! -z "${INFINISPAN_SASLMECHANISM}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.sasl-mechanism=${INFINISPAN_SASLMECHANISM}"); fi
 
     echo $infinispan_props
 }

--- a/s2i/modules/kogito-data-index/tests/bats/start.bats
+++ b/s2i/modules/kogito-data-index/tests/bats/start.bats
@@ -26,7 +26,7 @@ function clear_vars() {
 @test "check if infinispan auth is false" {
     clear_vars
     export INFINISPAN_USEAUTH="false"
-    local expected="-Dinfinispan_useauth=false"
+    local expected="-Dquarkus.infinispan-client.use-auth=false"
     run set_infinispan_props
     
     echo "Result is ${output} and expected is ${expected}" >&2
@@ -41,7 +41,7 @@ function clear_vars() {
     export INFINISPAN_AUTHREALM="default"
     export INFINISPAN_SASLMECHANISM="PLAIN"
     
-    local expected="-Dinfinispan_username=developer -Dinfinispan_password=developer -Dinfinispan_useauth=true -Dinfinispan_authrealm=default -Dinfinispan_saslmechanism=PLAIN"
+    local expected="-Dquarkus.infinispan-client.auth-username=developer -Dquarkus.infinispan-client.auth-password=developer -Dquarkus.infinispan-client.use-auth=true -Dquarkus.infinispan-client.auth-realm=default -Dquarkus.infinispan-client.sasl-mechanism=PLAIN"
     run set_infinispan_props
     
     echo "Result is ${output} and expected is ${expected}" >&2
@@ -52,7 +52,7 @@ function clear_vars() {
     clear_vars
     export INFINISPAN_USERNAME="developer"
     export INFINISPAN_USEAUTH="false"
-    local expected="-Dinfinispan_username=developer -Dinfinispan_useauth=true"
+    local expected="-Dquarkus.infinispan-client.auth-username=developer -Dquarkus.infinispan-client.use-auth=true"
 
     run set_infinispan_props
     
@@ -63,7 +63,7 @@ function clear_vars() {
 @test "when use auth is set to nonsense and no credentials" {
     clear_vars
     export INFINISPAN_USEAUTH="dsadsadasdsa"
-    local expected="-Dinfinispan_useauth=false"
+    local expected="-Dquarkus.infinispan-client.use-auth=false"
 
     run set_infinispan_props
     
@@ -75,7 +75,7 @@ function clear_vars() {
     clear_vars
     export INFINISPAN_USEAUTH="dsadsadasdsa"
     export INFINISPAN_USERNAME="developer"
-    local expected="-Dinfinispan_username=developer -Dinfinispan_useauth=true"
+    local expected="-Dquarkus.infinispan-client.auth-username=developer -Dquarkus.infinispan-client.use-auth=true"
 
     run set_infinispan_props
     
@@ -86,7 +86,7 @@ function clear_vars() {
 @test "when use auth is set to true and no credentials" {
     clear_vars
     export INFINISPAN_USEAUTH="true"
-    local expected="-Dinfinispan_username=developer -Dinfinispan_useauth=true"
+    local expected="-Dquarkus.infinispan-client.auth-username=developer -Dquarkus.infinispan-client.use-auth=true"
 
     run set_infinispan_props
     # exit(1)

--- a/s2i/tests/features/kogito-quarkus-index.feature
+++ b/s2i/tests/features/kogito-quarkus-index.feature
@@ -20,7 +20,7 @@ Feature: Kogito-quarkus-ubi8 feature.
     When container is started with env
       | variable     | value |
       | SCRIPT_DEBUG | true  |
-    Then container log should contain infinispan_useauth = false
+    Then container log should contain quarkus.infinispan-client.use-auth = false
 
   Scenario: verify if auth is correctly set
     When container is started with env
@@ -29,9 +29,9 @@ Feature: Kogito-quarkus-ubi8 feature.
       | INFINISPAN_USEAUTH  | true        |
       | INFINISPAN_USERNAME | IamNotExist |
       | INFINISPAN_PASSWORD | hard2guess  |
-    Then container log should contain infinispan_useauth = true
-    And container log should contain infinispan_password = hard2guess
-    And container log should contain infinispan_username = IamNotExist
+    Then container log should contain quarkus.infinispan-client.use-auth = true
+    And container log should contain quarkus.infinispan-client.auth-password = hard2guess
+    And container log should contain quarkus.infinispan-client.auth-username = IamNotExist
 
   Scenario: verify if all parameters are correctly set
     When container is started with env
@@ -42,11 +42,11 @@ Feature: Kogito-quarkus-ubi8 feature.
       | INFINISPAN_PASSWORD      | hard2guess  |
       | INFINISPAN_AUTHREALM     | SecretRealm |
       | INFINISPAN_SASLMECHANISM | COOLGSSAPI  |
-    Then container log should contain infinispan_useauth = true
-    And container log should contain infinispan_password = hard2guess
-    And container log should contain infinispan_username = IamNotExist
-    And container log should contain infinispan_authrealm = SecretRealm
-    And container log should contain infinispan_saslmechanism = COOLGSSAPI
+    Then container log should contain quarkus.infinispan-client.use-auth = true
+    And container log should contain quarkus.infinispan-client.auth-password = hard2guess
+    And container log should contain quarkus.infinispan-client.auth-username = IamNotExist
+    And container log should contain quarkus.infinispan-client.auth-realm = SecretRealm
+    And container log should contain quarkus.infinispan-client.sasl-mechanism = COOLGSSAPI
 
   Scenario: verify if all parameters are correctly set
     When container is started with env


### PR DESCRIPTION
~See: https://github.com/kiegroup/kogito-runtimes/pull/176~
See:
https://github.com/kiegroup/kogito-runtimes/pull/212

Now we are using the standard properties from the quarkus extension:
https://quarkus.io/guides/infinispan-client-guide#quarkus-infinispan-client_configuration 