### PR TITLE
[KOGITO-419] - Limiting jvm xmx for native in 80% of container memory…

### DIFF
--- a/s2i/modules/graalvm/19.x/added/memory-limit.sh
+++ b/s2i/modules/graalvm/19.x/added/memory-limit.sh
@@ -12,13 +12,18 @@
 # its value must be in binary bytes.
 
 function configure() {
-    # native builds requires at least 1024m (1073741824=1024MB - 1 MB = 2^20 B in base 2)
     # does not accepts
     if [[  "${LIMIT_MEMORY}" =~ ^[-+]?[0-9]+{9}$ ]]; then
-        if [ "${LIMIT_MEMORY}" -lt 1073741824 ]; then
-            echo "Provided memory (${LIMIT_MEMORY}) limit is too small, native build will use all available memory"
+        # native builds requires at least 1024m (1073741824=1024MB - 1 MB = 2^20 B in base 2)
+        local limit=1073741824
+        # only 80% of the actual limit will be used for the JVM
+        local jvm_limit_memory=$(($LIMIT_MEMORY*80/100))
+        echo "Limit memory for this container is set to ${LIMIT_MEMORY}. Allocated memory for JVM will be set to ${jvm_limit_memory}."
+        if [ "${jvm_limit_memory}" -lt "${limit}" ]; then
+            limit=$(echo "scale=1; ${limit} / (80/100)" | bc -l)
+            printf "Provided memory (${LIMIT_MEMORY}) limit is too small (should be greater then %.0f bytes), native build will use all available memory.\n" $limit
         else
-            export KOGITO_OPTS="${KOGITO_OPTS} -Dnative-image.xmx=${LIMIT_MEMORY}"
+            export KOGITO_OPTS="${KOGITO_OPTS} -Dnative-image.xmx=${jvm_limit_memory}"
         fi
     else
         echo "Provided memory (${LIMIT_MEMORY}) limit is not valid, native build will use all available memory"

--- a/s2i/tests/bats/memory-limits.bats
+++ b/s2i/tests/bats/memory-limits.bats
@@ -4,24 +4,31 @@
 source $BATS_TEST_DIRNAME/../../modules/graalvm/19.x/added/memory-limit.sh
 
 @test "test a valid memory limit value" {
-    export LIMIT_MEMORY="1073741824"
-    local expected=" -Dnative-image.xmx=1073741824"
+    export LIMIT_MEMORY="1342177280"
+    local expected=" -Dnative-image.xmx=1073741824" # 80% of LIMIT_MEMORY, top expected by JVM
     configure
     echo "Expected: ${expected}"
     echo "Result: ${KOGITO_OPTS}"
     [ "${expected}" = "${KOGITO_OPTS}" ]
 }
 
+@test "test a result jvm memory with float points" {
+    export LIMIT_MEMORY="2147483648" # 80% is 1717986918.4
+    local expected=" -Dnative-image.xmx=1717986918"
+    configure
+    echo "Expected: ${expected}"
+    echo "Result: ${KOGITO_OPTS}"
+    [ "${expected}" = "${KOGITO_OPTS}" ]
+}
 
 @test "test a small memory limit value" {
     export LIMIT_MEMORY="1073741600"
-    local expected="Provided memory (1073741600) limit is too small, native build will use all available memory"
+    local expected="Provided memory (1073741600) limit is too small"
     local result=$(configure)
     echo "Expected: ${expected}"
     echo "Result: ${result}"
-    [ "${expected}" = "${result}" ]
+    [[ ${result} == *"${expected}"* ]]
 }
-
 
 @test "test a invalid memory limit value" {
     export LIMIT_MEMORY="1024m"

--- a/s2i/tests/features/kogito-quarkus-ubi8-s2i.feature
+++ b/s2i/tests/features/kogito-quarkus-ubi8-s2i.feature
@@ -69,7 +69,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
       | wait            | 80                       |
       | expected_phrase | Mario is older than Mark |
     And file /home/kogito/bin/drools-quarkus-example-0.5.0-runner should exist
-    And s2i build log should contain -J-Xmx2147483648
+    And s2i build log should contain -J-Xmx1717986918
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build


### PR DESCRIPTION
… limit

See:
https://issues.jboss.org/browse/KOGITO-419

The rationale behind this change is to try to limit the builder JVM to use only 80% of the container's memory to its heap size, the rest will be handled by the system. Without this change, builds will fail unless it's given an absurd amount of memory.

This first screenshot illustrates the a build before the change:

https://pasteboard.co/IDk0xVn.png

The build fails because the 10Gi of memory was added to the heap directly, with no room for other tasks within the build.

The second screenshot we can see that the build behaves like it should:

https://pasteboard.co/IDk0Ps8.png

The remaining 20% is there to give space to other process to handle the build.

Still, if the memory is set to a lower value (like 4GB), the container will be killed since won't have enough memory for the native-image component itself.