### PR TITLE
[KOGITO-382] - Removing snapshot builds from maven archetypes

### DIFF
--- a/s2i/modules/kogito-quarkus-ubi8-s2i/module.yaml
+++ b/s2i/modules/kogito-quarkus-ubi8-s2i/module.yaml
@@ -3,3 +3,7 @@ version: "0.5.0"
 name: kogito-quarkus-ubi8-s2i
 execute:
   - script: configure
+
+envs:
+- name: "KOGITO_VERSION"
+  value: "0.5.0"

--- a/s2i/modules/kogito-quarkus-ubi8-s2i/s2i/bin/assemble
+++ b/s2i/modules/kogito-quarkus-ubi8-s2i/s2i/bin/assemble
@@ -46,7 +46,7 @@ else
     echo "---> Generating project structure..."
 
     $MAVEN_HOME/bin/mvn archetype:generate -B -DarchetypeGroupId=org.kie.kogito -DarchetypeArtifactId=kogito-quarkus-archetype \
-	-DarchetypeVersion=8.0.0-SNAPSHOT -DgroupId=com.company -DartifactId=project -s $KOGITO_HOME/.m2/settings.xml
+	-DarchetypeVersion=$KOGITO_VERSION -DgroupId=com.company -DartifactId=project -s $KOGITO_HOME/.m2/settings.xml
 
     # copy resources into the generated project
     for item in *
@@ -55,7 +55,7 @@ else
             echo "--> Skipping generated project ..."
         else
             echo "--> Coping resource $item"
-            cp -R $item project/src/main/resources
+            cp -R "$item" project/src/main/resources
         fi
     done
 

--- a/s2i/modules/kogito-springboot-ubi8-s2i/module.yaml
+++ b/s2i/modules/kogito-springboot-ubi8-s2i/module.yaml
@@ -3,3 +3,7 @@ version: "0.5.0"
 name: kogito-springboot-ubi8-s2i
 execute:
   - script: configure
+
+envs:
+- name: "KOGITO_VERSION"
+  value: "0.5.0"

--- a/s2i/modules/kogito-springboot-ubi8-s2i/s2i/bin/assemble
+++ b/s2i/modules/kogito-springboot-ubi8-s2i/s2i/bin/assemble
@@ -38,7 +38,7 @@ else
 	echo "---> Generating project structure..."
 
 	$MAVEN_HOME/bin/mvn archetype:generate -B -DarchetypeGroupId=org.kie.kogito \
-	-DarchetypeArtifactId=kogito-springboot-archetype -DarchetypeVersion=8.0.0-SNAPSHOT \
+	-DarchetypeArtifactId=kogito-springboot-archetype -DarchetypeVersion=$KOGITO_VERSION \
 	-DgroupId=com.company -DartifactId=project -s $KOGITO_HOME/.m2/settings.xml
 
 	# copy resources into the generated project
@@ -48,7 +48,7 @@ else
 			echo "--> Skipping generated project ..."
 		else
 			echo "--> Coping resource $item"
-			cp -R $item project/src/main/resources
+			cp -R "$item" project/src/main/resources
 		fi
 	done
 

--- a/s2i/tests/features/kogito-quarkus-ubi8-s2i.feature
+++ b/s2i/tests/features/kogito-quarkus-ubi8-s2i.feature
@@ -40,7 +40,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And file /home/kogito/bin/drools-quarkus-example-0.5.0-runner.jar should exist
 
     Scenario: Verify if the multi-module s2i build is finished as expected performing a non native build and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples from . using 0.5.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.5.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable          | value                           |
       | NATIVE            | false                           |
       | ARTIFACT_DIR      | drools-quarkus-example/target   |
@@ -108,4 +108,8 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And run sh -c 'echo $GRAALVM_HOME' in container and immediately check its output for /usr/share/graalvm
     And run sh -c 'echo $GRAALVM_VERSION' in container and immediately check its output for 19.2.0.1
 
-
+    Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly
+    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using 0.5.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+      | variable          | value                           |
+      | NATIVE            | false                           |
+    Then file /home/kogito/bin/project-1.0-SNAPSHOT-runner.jar should exist

--- a/s2i/tests/test-apps/clone-repo.sh
+++ b/s2i/tests/test-apps/clone-repo.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 #
-# Clone the kogito-examples and edit the drools-quarkus-example
-# by adding the application.properties file telling quarkus to start on
-# port 10000, the purpose of this tests is make sure that the images
-# will ensure the use of the port 8080.
+# Clone the kogito-examples and edit the drools-quarkus-example and dmn-quarkus-example for testing purposes
 
-CURRENT_DIR=`pwd`
+TEST_DIR=`pwd`
 cd /tmp
 rm -rf kogito-examples/
 git clone https://github.com/kiegroup/kogito-examples.git
 cd kogito-examples/drools-quarkus-example
 git fetch origin --tags
-git checkout 0.5.0
-cp ${CURRENT_DIR}/application.properties src/main/resources/META-INF/
+git checkout -b 0.5.0 0.5.0
+
+# by adding the application.properties file telling quarkus to start on
+# port 10000, the purpose of this tests is make sure that the images
+# will ensure the use of the port 8080.
+cp ${TEST_DIR}/application.properties src/main/resources/META-INF/
+
+# preparing directory to run kogito maven archetypes tests
+cp /tmp/kogito-examples/dmn-quarkus-example/src/main/resources/* /tmp/kogito-examples/dmn-quarkus-example/
+rm -rf /tmp/kogito-examples/dmn-quarkus-example/src
+rm -rf /tmp/kogito-examples/dmn-quarkus-example/pom.xml
+
 git add --all
 git commit -am "test"
-


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KOGITO-382

Just removed the SNAPSHOT from the archetype generation, introduced the `KOGITO_VERSION` env var to the module and add a new test to verify the maven archetype generation for the `dmn-quarkus-example` example.