### PR TITLE
[KOGITO-695] - Improve the Kogito process for pushing rc images.

### DIFF
--- a/s2i/Makefile
+++ b/s2i/Makefile
@@ -65,23 +65,5 @@ _push:
 .PHONY: push-staging
 push-staging: build _push-staging
 _push-staging:
-	docker tag quay.io/kiegroup/kogito-quarkus-ubi8:${IMAGE_VERSION} quay.io/kiegroup/kogito-quarkus-ubi8:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-quarkus-ubi8:${IMAGE_VERSION}-rc1
+	python3 push-staging.py
 
-	docker tag quay.io/kiegroup/kogito-quarkus-jvm-ubi8:${IMAGE_VERSION} quay.io/kiegroup/kogito-quarkus-jvm-ubi8:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-quarkus-jvm-ubi8:${IMAGE_VERSION}-rc1
-
-	docker tag quay.io/kiegroup/kogito-quarkus-ubi8-s2i:${IMAGE_VERSION} quay.io/kiegroup/kogito-quarkus-ubi8-s2i:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-quarkus-ubi8-s2i:${IMAGE_VERSION}-rc1
-
-	docker tag quay.io/kiegroup/kogito-springboot-ubi8:${IMAGE_VERSION} quay.io/kiegroup/kogito-springboot-ubi8:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-springboot-ubi8:${IMAGE_VERSION}-rc1
-
-	docker tag quay.io/kiegroup/kogito-springboot-ubi8-s2i:${IMAGE_VERSION} quay.io/kiegroup/kogito-springboot-ubi8-s2i:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-springboot-ubi8-s2i:${IMAGE_VERSION}-rc1
-
-	docker tag quay.io/kiegroup/kogito-data-index:${IMAGE_VERSION} quay.io/kiegroup/kogito-data-index:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-data-index:${IMAGE_VERSION}-rc1
-	
-	docker tag quay.io/kiegroup/kogito-jobs-service:${IMAGE_VERSION} quay.io/kiegroup/kogito-jobs-service:${IMAGE_VERSION}-rc1
-	docker push quay.io/kiegroup/kogito-jobs-service:${IMAGE_VERSION}-rc1

--- a/s2i/image.yaml
+++ b/s2i/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "kogito-image-real-name-on-overrides-file"
-version: "0.7.0-rc1"
+version: "0.7.0"
 # until this issue is not fixed use 8.0 tag.
 # https://github.com/rpm-software-management/microdnf/issues/50
 # https://bugzilla.redhat.com/show_bug.cgi?id=1769831

--- a/s2i/push-staging.py
+++ b/s2i/push-staging.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python3
+# This script will be responsible to fetch the latest rc tags from each image and define the next
+# rc tag to avoid images get overriden.
+#
+# Requires QUAY_TOKEN env to be set.
+# export QUAY_TOKEN=XXXXX
+# this token can be retrieved from https://quay.io/repository/kiegroup
+#
+
+import docker
+import os
+import requests
+import yaml
+
+# All Kogito images
+IMAGES = ["kogito-quarkus-ubi8", "kogito-quarkus-jvm-ubi8", "kogito-quarkus-ubi8-s2i",
+          "kogito-springboot-ubi8", "kogito-springboot-ubi8-s2i", "kogito-data-index",
+          "kogito-jobs-service"]
+
+IMAGES_NEXT_RC_TAG = []
+QUAY_KOGITO_ORG_PLACE_HOLDER = "quay.io/kiegroup/{}:{}"
+QUAY_KOGITO_ORG_PLACE_HOLDER_NO_TAG = "quay.io/kiegroup/{}"
+
+
+def find_next_tag():
+    '''
+    Populate the IMAGES_NEXT_RC_TAGS with the next rc tag for each image.
+    '''
+    global IMAGES_NEXT_RC_TAG
+    for image in IMAGES:
+        tag = fetch_tag(image)
+        print("Next tag for image %s is %s" % (image, tag))
+        IMAGES_NEXT_RC_TAG.append('{}:{}'.format(image, tag))
+
+
+def fetch_tag(image):
+    '''
+    fetch the rcX tag for the given image, keep increasing until no rc tag is found
+    then return the next tag to be used.
+    :param image: image to be verified
+    :return: the next rc tag
+    '''
+    version = CURRENT_IMAGE_VERSION
+    while True:
+        url = 'https://quay.io/api/v1/repository/kiegroup/{}/tag/{}/images'.format(image, version)
+        print("Defining latest rc tag for image %s with url %s" % (image, url))
+        authorization = 'Bearer %s'.format(os.environ['QUAY_TOKEN'])
+        headers = {'content-type': 'application/json', 'Authorization': authorization}
+        response = requests.get(url, headers=headers)
+        if response.status_code == 404:
+            return version
+        else:
+            # increase number
+            current_number = version[-1]
+            print("Image found, current rc tag number is %s, increasing..." % current_number)
+            version = str.replace(version, current_number, str(int(current_number) + 1))
+
+
+def tag_and_push_images():
+    '''
+    tag and push the images to quay.io
+    '''
+    cli = docker.client.from_env()
+    current_version = get_current_version()
+    print("New rc tags %s" % IMAGES_NEXT_RC_TAG)
+    if '-rc' not in current_version:
+        for next_tag in IMAGES_NEXT_RC_TAG:
+            iname = str.split(next_tag, ':')[0]
+            iversion_next_tag = str.split(next_tag, ':')[1]
+            iname_tag = QUAY_KOGITO_ORG_PLACE_HOLDER.format(iname, current_version)
+            try:
+                print("Tagging image %s as %s" % (iname_tag, iversion_next_tag))
+                cr_tag = QUAY_KOGITO_ORG_PLACE_HOLDER_NO_TAG.format(iname)
+                cli.images.get(iname_tag).tag(cr_tag, iversion_next_tag)
+                print("Trying to push %s:%s" % (cr_tag, iversion_next_tag))
+                cli.images.push(cr_tag, iversion_next_tag)
+                print("Pushed")
+            except:
+                raise
+
+    else:
+        # if rc is already on the image version, just tag if needed and push it
+        for next_tag in IMAGES_NEXT_RC_TAG:
+            iname = str.split(next_tag, ':')[0]
+            iversion_next_tag = str.split(next_tag, ':')[1]
+            iname_tag = QUAY_KOGITO_ORG_PLACE_HOLDER.format(iname, current_version)
+            cr_tag = QUAY_KOGITO_ORG_PLACE_HOLDER_NO_TAG.format(iname)
+            try:
+                if iversion_next_tag != get_current_version():
+                    print("Tagging image %s as %s" % (iname_tag, iversion_next_tag))
+                    cli.images.get(iname_tag).tag(cr_tag, iversion_next_tag)
+
+                print("Trying to push %s:%s" % (cr_tag, iversion_next_tag))
+                cli.images.push(cr_tag, iversion_next_tag)
+            except:
+                raise
+
+
+def get_current_version():
+    '''
+    get the current image version from image.yaml. The version defined there will be considered
+    the point of truth, update it carefully.
+    :return: current image.yaml defined version
+    '''
+    with open('image.yaml') as image_yaml:
+        data = yaml.load(image_yaml, Loader=yaml.FullLoader)
+        return data['version']
+
+
+def find_current_rc_version():
+    '''
+    If the current version already includes the rc tag, keep it, otherwise add it -rc1 tag.
+    :return: the current image tag version
+    '''
+    global CURRENT_IMAGE_VERSION
+    version = get_current_version()
+    if '-rc' in version:
+        CURRENT_IMAGE_VERSION = version
+    else:
+        CURRENT_IMAGE_VERSION = version+'-rc1'
+    print("Current initial version is %s" % CURRENT_IMAGE_VERSION)
+
+
+if __name__ == "__main__":
+    if 'QUAY_TOKEN' not in  os.environ:
+        print("Env QUAY_TOKEN not found, aborting...")
+        os._exit(1)
+    find_current_rc_version()
+    find_next_tag()
+    tag_and_push_images()
+


### PR DESCRIPTION
Signed-off-by: Filippe Spolti <fspolti@redhat.com>

A python script was created to do the push-staging part.
It will read the current image version from image.yaml and tag the built images as CURRENT_VERSION-rcX where X will be increased if images with rcX is already available on quay.

An example of its execution:

```
$ python3 push-staging.py 
Current initial version is 0.7.0-rc1
Defining latest rc tag for image kogito-quarkus-ubi8 with url https://quay.io/api/v1/repository/kiegroup/kogito-quarkus-ubi8/tag/0.7.0-rc1/images
Image found, current rc tag number is 1, increasing...
Defining latest rc tag for image kogito-quarkus-ubi8 with url https://quay.io/api/v1/repository/kiegroup/kogito-quarkus-ubi8/tag/0.7.0-rc2/images
Next tag for image kogito-quarkus-ubi8 is 0.7.0-rc2
New rc tags ['kogito-quarkus-ubi8:0.7.0-rc2']
Tagging image quay.io/kiegroup/kogito-quarkus-ubi8:0.7.0 as 0.7.0-rc2
Trying to push quay.io/kiegroup/kogito-quarkus-ubi8:0.7.0-rc2
Pushed

```