### PR TITLE
Corrected test

### DIFF
--- a/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
+++ b/kogito-cloud-services/kogito-cloud-workitems/src/test/java/org/kie/kogito/cloud/workitems/KubernetesDiscoveredServiceWorkItemHandlerTest.java
@@ -47,7 +47,7 @@ public class KubernetesDiscoveredServiceWorkItemHandlerTest extends BaseKubernet
         final ObjectMeta metadata = new ObjectMeta();
         metadata.setName("test-kieserver");
         metadata.setNamespace(MOCK_NAMESPACE);
-        metadata.setLabels(Collections.singletonMap("service", "test-kieserver"));
+        metadata.setLabels(Collections.singletonMap("test-kieserver", "service"));
 
         final Service service = new Service("v1", "Service", metadata, serviceSpec, new ServiceStatus(new LoadBalancerStatus()));
         getClient().services().create(service);


### PR DESCRIPTION
Put the service name as label key, as search for a service will be done via the label key (see ServiceDiscovery#findEndpoint(namespace,service))

Was working until now because I think the kubernetes mock server was buggy. But testing with latest kubernetes-client and server-mock 4.6.4, test was failing ...