### PR TITLE
[KOGITO-1294] - Support for binary builds

### DIFF
--- a/s2i/Makefile
+++ b/s2i/Makefile
@@ -31,9 +31,9 @@ kogito-jobs-service:
 # Build and test all images
 .PHONY: test
 test:
+	cd tests/test-apps && sh clone-repo.sh
 	cekit -v test --overrides-file kogito-quarkus-overrides.yaml behave
 	cekit -v test --overrides-file kogito-quarkus-jvm-overrides.yaml behave
-	cd tests/test-apps && sh clone-repo.sh
 	cekit -v test --overrides-file kogito-quarkus-s2i-overrides.yaml behave
 	cekit -v test --overrides-file kogito-springboot-overrides.yaml behave
 	cekit -v test --overrides-file kogito-springboot-s2i-overrides.yaml behave

--- a/s2i/kogito-quarkus-overrides.yaml
+++ b/s2i/kogito-quarkus-overrides.yaml
@@ -17,6 +17,9 @@ envs:
 - name: JAVA_OPTIONS
   example: "-Dquarkus.log.level=DEBUG"
   description: JVM options passed to the Java command.
+- name: BINARY_BUILD
+  example: "true"
+  description: Enables binary builds for this image, meaning that the application binaries (e.g. maven target directory) will be uploaded to it.
 
 ports:
 - value: 8080

--- a/s2i/kogito-springboot-overrides.yaml
+++ b/s2i/kogito-springboot-overrides.yaml
@@ -17,6 +17,9 @@ envs:
 - name: JAVA_OPTIONS
   example: "-Ddebug=true"
   description: JVM options passed to the Java command.
+- name: BINARY_BUILD
+  example: "true"
+  description: Enables binary builds for this image, meaning that the application binaries (e.g. maven target directory) will be uploaded to it.
 
 ports:
 - value: 8080

--- a/s2i/modules/kogito-s2i-core/added/s2i-core
+++ b/s2i/modules/kogito-s2i-core/added/s2i-core
@@ -32,7 +32,7 @@ function assemble_runtime() {
 
         echo "---> [s2i-core] Adding custom labels..."
         if [ -e "${KOGITO_HOME}/bin/image_metadata.json" ]; then
-            mkdir -v /tmp/.s2i
+            mkdir -pv /tmp/.s2i
             mkdir -pv /tmp/src/.s2i/
             cp -v $KOGITO_HOME/bin/image_metadata.json /tmp/.s2i/image_metadata.json
             cp -v $KOGITO_HOME/bin/image_metadata.json /tmp/src/.s2i/image_metadata.json
@@ -50,9 +50,34 @@ function assemble_runtime() {
 
 # copy already built artifacts to the runtime image.
 function runtime_assemble() {
+    echo "-----> [s2i-core] Running runtime assemble script"
     cd ${S2I_DESTINATION_DIR}/src
-    cp -Rv --parents ./* ${KOGITO_HOME}/
+    if [ "${BINARY_BUILD^^}" == "TRUE" ] || ls | grep -E '*.jar|classes|maven*|*-runner|target' 1> /dev/null 2>&1; then
+        echo "-----> Binary build enabled, artifacts were uploaded directly to the image build"
+        if ls target 1> /dev/null 2>&1; then
+            echo "-----> Entire target dir uploaded"
+            cd "target"    
+        fi
+        if ls | grep -E '*-runner.jar' 1> /dev/null 2>&1; then
+            echo "-----> Found jar file, not native build"
+            NATIVE="FALSE"
+        fi
+        echo "-----> Cleaning up unneeded jar files"
+        rm -rfv *-tests.jar
+        rm -rfv *-sources.jar
+
+        echo "-----> Copying uploaded files to ${KOGITO_HOME}"
+        artifactDir="."
+        ARTIFACT_DIR=$artifactDir
+        handle_image_metadata_json
+        copy_kogito_app
+        copy_persistence_files
+    else
+        cp -Rv --parents ./* ${KOGITO_HOME}/
+    fi
     assemble_runtime
+    echo "-----> Cleaning up s2i directory"
+    rm -rfv ${S2I_DESTINATION_DIR}/src/*
 }
 
 

--- a/s2i/modules/kogito-s2i-core/tests/bats/s2i-core.bats
+++ b/s2i/modules/kogito-s2i-core/tests/bats/s2i-core.bats
@@ -108,7 +108,40 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "'./bin/myapp.jar' -> '$KOGITO_HOME/./bin/myapp.jar'" ]
+    [ "${lines[1]}" = "'./bin/myapp.jar' -> '$KOGITO_HOME/./bin/myapp.jar'" ]
+}
+
+@test "test runtime_assemble with binary builds" {
+    mkdir -p ${KOGITO_HOME}/bin
+    # emulating an upload
+    mkdir -p /tmp/src/
+    touch /tmp/src/myapp.jar
+    mkdir -p /tmp/src/lib
+    mkdir -p /tmp/src/classes
+    mkdir -p /tmp/src/maven-archiver
+
+    run runtime_assemble
+
+    echo "result= ${lines[@]}"
+    [ "$status" -eq 0 ]
+    [ "${lines[7]}" = "'./myapp.jar' -> '$KOGITO_HOME/bin/myapp.jar'" ]
+}
+
+@test "test runtime_assemble with binary builds entire target!" {
+    mkdir -p ${KOGITO_HOME}/bin
+    # emulating an upload
+    mkdir -p /tmp/src/target
+    touch /tmp/src/target/myapp.jar
+    touch /tmp/src/target/myapp-sources.jar
+    mkdir -p /tmp/src/target/lib
+    mkdir -p /tmp/src/target/classes
+    mkdir -p /tmp/src/target/maven-archiver
+
+    run runtime_assemble
+
+    echo "result= ${lines[@]}"
+    [ "$status" -eq 0 ]
+    [ "${lines[9]}" = "'./myapp.jar' -> '$KOGITO_HOME/bin/myapp.jar'" ]
 }
 
 

--- a/s2i/tests/features/kogito-quarkus-jvm-ubi8.feature
+++ b/s2i/tests/features/kogito-quarkus-jvm-ubi8.feature
@@ -18,3 +18,31 @@ Feature: Kogito-quarkus-ubi8 feature.
     Then run sh -c 'echo $JAVA_HOME' in container and immediately check its output for /usr/lib/jvm/java-1.8.0
     And run sh -c 'echo $JAVA_VENDOR' in container and immediately check its output for openjdk
     And run sh -c 'echo $JAVA_VERSION' in container and immediately check its output for 1.8.0
+
+  Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
+    Given s2i build /tmp/kogito-examples/drools-quarkus-example from target
+      | variable            | value                     |
+      | NATIVE              | false                     |
+      | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
+    Then check that page is served
+      | property        | value                    |
+      | port            | 8080                     |
+      | path            | /hello                   |
+      | wait            | 80                       |
+      | expected_phrase | Mario is older than Mark |
+    And file /home/kogito/bin/drools-quarkus-example-8.0.0-SNAPSHOT-runner.jar should exist
+
+  
+  Scenario: Verify if the binary build (forcing) is finished as expected and if it is listening on the expected port
+    Given s2i build /tmp/kogito-examples/drools-quarkus-example from target
+      | variable            | value                     |
+      | NATIVE              | false                     |
+      | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
+      | BINARY_BUILD        | true                      |
+    Then check that page is served
+      | property        | value                    |
+      | port            | 8080                     |
+      | path            | /hello                   |
+      | wait            | 80                       |
+      | expected_phrase | Mario is older than Mark |
+    And file /home/kogito/bin/drools-quarkus-example-8.0.0-SNAPSHOT-runner.jar should exist

--- a/s2i/tests/features/kogito-springboot-ubi8.feature
+++ b/s2i/tests/features/kogito-springboot-ubi8.feature
@@ -20,3 +20,31 @@ Feature: springboot-quarkus-ubi8 feature.
     And run sh -c 'echo $JAVA_VERSION' in container and immediately check its output for 1.8.0
 
 
+  Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
+    Given s2i build /tmp/kogito-examples/jbpm-springboot-example from target
+      | variable            | value        |
+      | JAVA_OPTIONS        | -Ddebug=true |
+    Then check that page is served
+      | property             | value     |
+      | port                 | 8080      |
+      | path                 | /orders/1 |
+      | wait                 | 80        |
+      | expected_status_code | 204       |
+    And file /home/kogito/bin/jbpm-springboot-example-8.0.0-SNAPSHOT.jar should exist
+    And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
+    And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
+
+  Scenario: Verify if the (forcing) binary build is finished as expected and if it is listening on the expected port
+    Given s2i build /tmp/kogito-examples/jbpm-springboot-example from target
+      | variable            | value        |
+      | JAVA_OPTIONS        | -Ddebug=true |
+      | BINARY_BUILD        | true         |
+    Then check that page is served
+      | property             | value     |
+      | port                 | 8080      |
+      | path                 | /orders/1 |
+      | wait                 | 80        |
+      | expected_status_code | 204       |
+    And file /home/kogito/bin/jbpm-springboot-example-8.0.0-SNAPSHOT.jar should exist
+    And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
+    And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true

--- a/s2i/tests/test-apps/clone-repo.sh
+++ b/s2i/tests/test-apps/clone-repo.sh
@@ -6,7 +6,6 @@ TEST_DIR=`pwd`
 cd /tmp
 rm -rf kogito-examples/
 git clone https://github.com/kiegroup/kogito-examples.git
-cd kogito-examples/drools-quarkus-example
 #git fetch origin --tags
 #git checkout -b 0.8.0 0.8.0
 
@@ -15,10 +14,15 @@ cd kogito-examples/drools-quarkus-example
 # will ensure the use of the port 8080.
 cp ${TEST_DIR}/application.properties src/main/resources/META-INF/
 
+# generating the app binaries to test the binary build
+mvn -f kogito-examples/drools-quarkus-example clean package -DskipTests
+mvn -f kogito-examples/jbpm-springboot-example clean package -DskipTests
+
 # preparing directory to run kogito maven archetypes tests
 cp /tmp/kogito-examples/dmn-quarkus-example/src/main/resources/* /tmp/kogito-examples/dmn-quarkus-example/
 rm -rf /tmp/kogito-examples/dmn-quarkus-example/src
 rm -rf /tmp/kogito-examples/dmn-quarkus-example/pom.xml
 
+cd kogito-examples/drools-quarkus-example
 git add --all
 git commit -am "test"


### PR DESCRIPTION
See:
https://issues.redhat.com/browse/KOGITO-1294

~**This a WIP, we are missing the behave tests. As soon as I get them, I'll mark it for review.**~

In this PR, we updated the function `runtime_assemble` to deal with uploaded compiled artifacts with the Kogito Maven Plugin. This function now calls s2i functions that handle with the compiled artifacts.

