### PR TITLE
[0.9.x][KOGITO-1770] - Updating images tests to reflect new examples naming

### DIFF
--- a/kogito-quarkus-jvm-overrides.yaml
+++ b/kogito-quarkus-jvm-overrides.yaml
@@ -32,7 +32,7 @@ modules:
 
 
 ## s2i build . quay.io/kiegroup/kogito-quarkus-ubi8-s2i:latest kogitotest:10.0 --runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-## where "." is the sources dir, ie: /data/dev/sources/kogito-examples/drools-quarkus-example
+## where "." is the sources dir, ie: /data/dev/sources/kogito-examples/rules-quarkus-helloworld
 run:
   workdir: "/home/kogito"
 

--- a/kogito-quarkus-overrides.yaml
+++ b/kogito-quarkus-overrides.yaml
@@ -35,7 +35,7 @@ modules:
 
 
 ## s2i build . quay.io/kiegroup/kogito-quarkus-ubi8-s2i:latest kogitotest:10.0 --runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
-## where "." is the sources dir, ie: /data/dev/sources/kogito-examples/drools-quarkus-example
+## where "." is the sources dir, ie: /data/dev/sources/kogito-examples/rules-quarkus-helloworld
 run:
   workdir: "/home/kogito"
 

--- a/tests/features/kogito-quarkus-jvm-ubi8.feature
+++ b/tests/features/kogito-quarkus-jvm-ubi8.feature
@@ -20,7 +20,7 @@ Feature: Kogito-quarkus-ubi8 feature.
     And run sh -c 'echo $JAVA_VERSION' in container and immediately check its output for 11
 
   Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples/drools-quarkus-example from target
+    Given s2i build /tmp/kogito-examples/rules-quarkus-helloworld from target
       | variable            | value                     |
       | NATIVE              | false                     |
       | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
@@ -28,13 +28,15 @@ Feature: Kogito-quarkus-ubi8 feature.
       | property        | value                    |
       | port            | 8080                     |
       | path            | /hello                   |
+      | request_method  | POST                     | 
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
-      | expected_phrase | Mario is older than Mark |
-    And file /home/kogito/bin/drools-quarkus-example-0.9.0-runner.jar should exist
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 
-  
   Scenario: Verify if the binary build (forcing) is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples/drools-quarkus-example from target
+    Given s2i build /tmp/kogito-examples/rules-quarkus-helloworld from target
       | variable            | value                     |
       | NATIVE              | false                     |
       | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
@@ -43,6 +45,9 @@ Feature: Kogito-quarkus-ubi8 feature.
       | property        | value                    |
       | port            | 8080                     |
       | path            | /hello                   |
+      | request_method  | POST                     | 
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
-      | expected_phrase | Mario is older than Mark |
-    And file /home/kogito/bin/drools-quarkus-example-0.9.0-runner.jar should exist
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist

--- a/tests/features/kogito-quarkus-ubi8-s2i.feature
+++ b/tests/features/kogito-quarkus-ubi8-s2i.feature
@@ -2,22 +2,25 @@
 Feature: kogito-quarkus-ubi8-s2i image tests
 
   Scenario: Verify if the s2i build is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples from drools-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable       | value                     |
       | LIMIT_MEMORY   | 3221225472                |
     Then check that page is served
       | property        | value                    |
       | port            | 8080                     |
       | path            | /hello                   |
+      | request_method  | POST                     | 
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
-      | expected_phrase | Mario is older than Mark |
-    And file /home/kogito/bin/drools-quarkus-example-0.9.0-runnershould exist
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
     And file /home/kogito/ssl-libs/libsunec.so should exist
     And file /home/kogito/cacerts should exist
     And s2i build log should contain -J-Xmx2576980377
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from drools-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable            | value                     |
       | NATIVE              | false                     |
       | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
@@ -25,30 +28,36 @@ Feature: kogito-quarkus-ubi8-s2i image tests
       | property        | value                    |
       | port            | 8080                     |
       | path            | /hello                   |
+      | request_method  | POST                     | 
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
-      | expected_phrase | Mario is older than Mark |
-    And file /home/kogito/bin/drools-quarkus-example-0.9.0-runner.jar should exist
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
     And container log should contain DEBUG [io.qua.
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Dquarkus.log.level=DEBUG
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples from drools-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable | value |
       | NATIVE   | false |
     Then check that page is served
       | property        | value                    |
       | port            | 8080                     |
       | path            | /hello                   |
+      | request_method  | POST                     | 
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
-      | expected_phrase | Mario is older than Mark |
-    And file /home/kogito/bin/drools-quarkus-example-0.9.0-runner.jar should exist
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build with persistence enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from jbpm-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable          | value         |
       | NATIVE            | false         |
       | MAVEN_ARGS_APPEND | -Ppersistence |
-    Then file /home/kogito/bin/jbpm-quarkus-example-0.9.0-runner.jar should exist
+    Then file /home/kogito/bin/process-quarkus-example-runner.jar should exist
     And s2i build log should contain '/home/kogito/bin/demo.orders.proto' -> '/home/kogito/data/protobufs/demo.orders.proto'
     And s2i build log should contain '/home/kogito/bin/persons.proto' -> '/home/kogito/data/protobufs/persons.proto'
     And s2i build log should contain ---> [persistence] generating md5 for persistence files
@@ -56,11 +65,11 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
 
   Scenario: Verify if the s2i build is finished as expected performing a native build with persistence enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from jbpm-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable          | value         |
       | NATIVE            | true          |
       | MAVEN_ARGS_APPEND | -Ppersistence |
-    Then file /home/kogito/bin/jbpm-quarkus-example-0.9.0-runnershould exist
+    Then file /home/kogito/bin/process-quarkus-example-runner should exist
     And s2i build log should contain '/home/kogito/bin/demo.orders.proto' -> '/home/kogito/data/protobufs/demo.orders.proto'
     And s2i build log should contain '/home/kogito/bin/persons.proto' -> '/home/kogito/data/protobufs/persons.proto'
     And s2i build log should contain ---> [persistence] generating md5 for persistence files
@@ -71,25 +80,28 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.9.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable          | value                           |
       | NATIVE            | false                           |
-      | ARTIFACT_DIR      | drools-quarkus-example/target   |
-      | MAVEN_ARGS_APPEND | -pl drools-quarkus-example -am  |
+      | ARTIFACT_DIR      | rules-quarkus-helloworld/target   |
+      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am  |
     Then check that page is served
       | property        | value                    |
       | port            | 8080                     |
       | path            | /hello                   |
+      | request_method  | POST                     | 
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
-      | expected_phrase | Mario is older than Mark |
-    And file /home/kogito/bin/drools-quarkus-example-0.9.0-runner.jar should exist
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 
   Scenario: Perform a incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from drools-quarkus-example with env and incremental using 0.9.0
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.9.0
       | variable          | value                  |
       | NATIVE            | false                  |
     Then s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from drools-quarkus-example with env and incremental using 0.9.0
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.9.0
       | variable          | value    |
       | NATIVE            | false    |
     Then s2i build log should contain Expanding artifacts from incremental build...

--- a/tests/features/kogito-springboot-ubi8-s2i.feature
+++ b/tests/features/kogito-springboot-ubi8-s2i.feature
@@ -3,7 +3,7 @@
 Feature: kogito-springboot-ubi8-s2i image tests
 
   Scenario: Verify if the s2i build is finished as expected
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from jbpm-springboot-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using 0.9.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
       | variable            | value        |
       | JAVA_OPTIONS        | -Ddebug=true |
     Then check that page is served
@@ -12,7 +12,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/jbpm-springboot-example-0.9.0.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
@@ -20,31 +20,31 @@ Feature: kogito-springboot-ubi8-s2i image tests
     Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.9.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
       | variable            | value                           |
       | JAVA_OPTIONS        | -Ddebug=true                    |
-      | ARTIFACT_DIR        | jbpm-springboot-example/target   |
-      | MAVEN_ARGS_APPEND   | -pl jbpm-springboot-example -am  |
+      | ARTIFACT_DIR        | process-springboot-example/target   |
+      | MAVEN_ARGS_APPEND   | -pl process-springboot-example -am  |
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/jbpm-springboot-example-0.9.0.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
   Scenario: Scenario: Perform a incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from jbpm-springboot-example with env and incremental using 0.9.0
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using 0.9.0
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/jbpm-springboot-example-0.9.0.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from jbpm-springboot-example with env and incremental using 0.9.0
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using 0.9.0
     Then s2i build log should contain Expanding artifacts from incremental build...
     And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
 

--- a/tests/features/kogito-springboot-ubi8.feature
+++ b/tests/features/kogito-springboot-ubi8.feature
@@ -21,7 +21,7 @@ Feature: springboot-quarkus-ubi8 feature.
 
 
   Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples/jbpm-springboot-example from target
+    Given s2i build /tmp/kogito-examples/process-springboot-example from target
       | variable            | value        |
       | JAVA_OPTIONS        | -Ddebug=true |
     Then check that page is served
@@ -30,12 +30,12 @@ Feature: springboot-quarkus-ubi8 feature.
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/jbpm-springboot-example-0.9.0.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
   Scenario: Verify if the (forcing) binary build is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples/jbpm-springboot-example from target
+    Given s2i build /tmp/kogito-examples/process-springboot-example from target
       | variable            | value        |
       | JAVA_OPTIONS        | -Ddebug=true |
       | BINARY_BUILD        | true         |
@@ -45,6 +45,6 @@ Feature: springboot-quarkus-ubi8 feature.
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/jbpm-springboot-example-0.9.0.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true

--- a/tests/test-apps/clone-repo.sh
+++ b/tests/test-apps/clone-repo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Clone the kogito-examples and edit the drools-quarkus-example and dmn-quarkus-example for testing purposes
+# Clone the kogito-examples and edit the rules-quarkus-helloworld and dmn-quarkus-example for testing purposes
 
 TEST_DIR=`pwd`
 cd /tmp
@@ -11,8 +11,8 @@ git fetch origin --tags
 git checkout -b 0.9.0 0.9.0
 
 # generating the app binaries to test the binary build
-mvn -f drools-quarkus-example clean package -DskipTests
-mvn -f jbpm-springboot-example clean package -DskipTests
+mvn -f rules-quarkus-helloworld clean package -DskipTests
+mvn -f process-springboot-example clean package -DskipTests
 
 # preparing directory to run kogito maven archetypes tests
 cp /tmp/kogito-examples/dmn-quarkus-example/src/main/resources/* /tmp/kogito-examples/dmn-quarkus-example/
@@ -22,8 +22,8 @@ rm -rf /tmp/kogito-examples/dmn-quarkus-example/pom.xml
 # by adding the application.properties file telling quarkus to start on
 # port 10000, the purpose of this tests is make sure that the images
 # will ensure the use of the port 8080.
-cp ${TEST_DIR}/application.properties kogito-examples/drools-quarkus-example/src/main/resources/META-INF/
+cp ${TEST_DIR}/application.properties kogito-examples/rules-quarkus-helloworld/src/main/resources/META-INF/
 
-cd drools-quarkus-example
-git add --all
+cd rules-quarkus-helloworld
+git add --all  :/
 git commit -am "test"


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Cherry-pick for: https://github.com/kiegroup/kogito-images/pull/132

I think won't work in the CI since we don't have this naming on 0.9.0:

```sh
# clone-repo.sh
git checkout -b 0.9.0 0.9.0
```

Depends on: https://github.com/kiegroup/kogito-images/pull/135