### PR TITLE
[0.9.x][KOGITO-1828] Update Jobs-services, data-index and mgmt console SNAPSHOT artefacts

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "kogito-image-real-name-on-overrides-file"
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 # until this issue is not fixed use 8.0 tag.
 # https://github.com/rpm-software-management/microdnf/issues/50
 # https://bugzilla.redhat.com/show_bug.cgi?id=1769831

--- a/kogito-imagestream.yaml
+++ b/kogito-imagestream.yaml
@@ -15,18 +15,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Runtime image for Kogito based on Quarkus native image
             iconClass: icon-jbpm
             tags: runtime,kogito,quarkus
             supports: quarkus
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-ubi8:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-quarkus-ubi8:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -36,18 +36,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Runtime image for Kogito based on Quarkus JVM image
             iconClass: icon-jbpm
             tags: runtime,kogito,quarkus,jvm
             supports: quarkus
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -57,18 +57,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Platform for building Kogito based on Quarkus
             iconClass: icon-jbpm
             tags: builder,kogito,quarkus
             supports: quarkus
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -78,18 +78,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Runtime image for Kogito based on SpringBoot
             iconClass: icon-jbpm
             tags: runtime,kogito,springboot
             supports: springboot
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-springboot-ubi8:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-springboot-ubi8:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -99,18 +99,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Platform for building Kogito based on Quarkus
             iconClass: icon-jbpm
             tags: builder,kogito,springboot
             supports: springboot
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -120,18 +120,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Runtime image for the Kogito Data Index Service
             iconClass: icon-jbpm
             tags: kogito,data-index
             supports: persistence backed by Infinispan server
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-data-index:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-data-index:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -141,18 +141,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Runtime image for the Kogito Jobs Service
             iconClass: icon-jbpm
             tags: kogito,jobs-service
             supports: out-of-box process timers
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-jobs-service:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-jobs-service:0.9.1-rc2
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -162,16 +162,16 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc1'
+        - name: '0.9.1-rc2'
           annotations:
             description: Runtime image for the Kogito Management Console
             iconClass: icon-jbpm
             tags: kogito,management-console
             supports: business process management
-            version: '0.9.1-rc1'
+            version: '0.9.1-rc2'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-management-console:0.9.1-rc1
+            name: quay.io/kiegroup/kogito-management-console:0.9.1-rc2
 

--- a/modules/kogito-data-index/module.yaml
+++ b/modules/kogito-data-index/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.dataindex
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 artifacts:
   - name: kogito-data-index-runner.jar

--- a/modules/kogito-data-index/module.yaml
+++ b/modules/kogito-data-index/module.yaml
@@ -4,8 +4,8 @@ version: "0.9.1-rc2"
 
 artifacts:
   - name: kogito-data-index-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/data-index-service/0.9.1-SNAPSHOT/data-index-service-0.9.1-20200409.104935-9-runner.jar
-    md5: a7f38c232405f23fddc73c617b5a8307
+    url: https://repository.jboss.org/org/kie/kogito/data-index-service/0.9.1-SNAPSHOT/data-index-service-0.9.1-20200410.154951-11-runner.jar
+    md5: cf5549ad15725a3a4e69f085da56683b
 
 execute:
   - script: configure

--- a/modules/kogito-image-dependencies/module.yaml
+++ b/modules/kogito-image-dependencies/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.image.dependencies
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 description: holds common dependencies across images
 
 execute:

--- a/modules/kogito-infinispan-properties/module.yaml
+++ b/modules/kogito-infinispan-properties/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.infinispan.properties
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 envs:
   - name: "INFINISPAN_USEAUTH"

--- a/modules/kogito-jobs-service/module.yaml
+++ b/modules/kogito-jobs-service/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.jobs.service
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 artifacts:
   - name: kogito-jobs-service-runner.jar

--- a/modules/kogito-jobs-service/module.yaml
+++ b/modules/kogito-jobs-service/module.yaml
@@ -4,8 +4,8 @@ version: "0.9.1-rc2"
 
 artifacts:
   - name: kogito-jobs-service-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/jobs-service/0.9.1-SNAPSHOT/jobs-service-0.9.1-20200409.104441-9-runner.jar
-    md5: d8559ab6f897436918ea5f150a7b9b10
+    url: https://repository.jboss.org/org/kie/kogito/jobs-service/0.9.1-SNAPSHOT/jobs-service-0.9.1-20200410.154450-11-runner.jar
+    md5: d7e781cbdb4b5968185699e03614a437
 
 execute:
   - script: configure

--- a/modules/kogito-jq/module.yaml
+++ b/modules/kogito-jq/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.jq
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 modules:
   install:

--- a/modules/kogito-kubernetes-client/module.yaml
+++ b/modules/kogito-kubernetes-client/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.kubernetes.client
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure

--- a/modules/kogito-launch-scripts/module.yaml
+++ b/modules/kogito-launch-scripts/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.launch.scripts
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure

--- a/modules/kogito-logging/module.yaml
+++ b/modules/kogito-logging/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.logging
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure

--- a/modules/kogito-management-console/module.yaml
+++ b/modules/kogito-management-console/module.yaml
@@ -8,8 +8,8 @@ envs:
 
 artifacts:
   - name: kogito-management-console-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/management-console/0.9.1-SNAPSHOT/management-console-0.9.1-20200409.105335-9-runner.jar
-    md5: 9cbbffb033913cfc9fe8c37dbfc427cf
+    url: https://repository.jboss.org/org/kie/kogito/management-console/0.9.1-SNAPSHOT/management-console-0.9.1-20200410.155354-11-runner.jar
+    md5: afd4885e4c33884e744adaaed3e280b7
 
 execute:
   - script: configure

--- a/modules/kogito-management-console/module.yaml
+++ b/modules/kogito-management-console/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.management.console
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 envs:
   - name: "KOGITO_DATAINDEX_HTTP_URL"

--- a/modules/kogito-persistence/module.yaml
+++ b/modules/kogito-persistence/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.persistence
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 modules:
   install:

--- a/modules/kogito-quarkus-jvm/module.yaml
+++ b/modules/kogito-quarkus-jvm/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.quarkus.jvm
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure

--- a/modules/kogito-quarkus-s2i/module.yaml
+++ b/modules/kogito-quarkus-s2i/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.quarkus.s2i
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure
 
 envs:
   - name: "KOGITO_VERSION"
-    value: "0.9.1-rc1"
+    value: "0.9.1-rc2"

--- a/modules/kogito-quarkus/module.yaml
+++ b/modules/kogito-quarkus/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.quarkus
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure

--- a/modules/kogito-s2i-core/module.yaml
+++ b/modules/kogito-s2i-core/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.s2i.core
-version: '0.9.1-rc1'
+version: '0.9.1-rc2'
 description: Kogito s2i core module. All s2i files shoul be placed here.
 
 labels:

--- a/modules/kogito-springboot-s2i/module.yaml
+++ b/modules/kogito-springboot-s2i/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.springboot.s2i
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure
 
 envs:
   - name: "KOGITO_VERSION"
-    value: "0.9.1-rc1"
+    value: "0.9.1-rc2"

--- a/modules/kogito-springboot/module.yaml
+++ b/modules/kogito-springboot/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.springboot
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: configure

--- a/modules/kogito-system-user/module.yaml
+++ b/modules/kogito-system-user/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.system.user
-version: "0.9.1-rc1"
+version: "0.9.1-rc2"
 
 execute:
   - script: add-user


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-1828

jobs-services snapshot version: jobs-service-0.9.1-20200410.154450-11-runner.jar
md5: d7e781cbdb4b5968185699e03614a437

data-index snapshot version: data-index-service-0.9.1-20200410.154951-11-runner.jar
md5: cf5549ad15725a3a4e69f085da56683b

management-console snapshot version: management-console-0.9.1-20200410.155354-11-runner.jar
md5: afd4885e4c33884e744adaaed3e280b7

Image tag: 0.9.1-rc2

Signed-off-by: tradisso tradisso@redhat.com