### PR TITLE
[KOGITO-1727] - Release Kogito Images 0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-management-console:${IMAGE_VERSION} quay.io/kiegroup/kogito-management-console:${SHORTENED_LATEST_VERSION}
 endif
 
+
 # Build and test all images
 .PHONY: test
 test:

--- a/image.yaml
+++ b/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "kogito-image-real-name-on-overrides-file"
-version: "0.9.1-rc2"
+version: "0.9.1"
 # until this issue is not fixed use 8.0 tag.
 # https://github.com/rpm-software-management/microdnf/issues/50
 # https://bugzilla.redhat.com/show_bug.cgi?id=1769831

--- a/kogito-imagestream.yaml
+++ b/kogito-imagestream.yaml
@@ -15,18 +15,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Runtime image for Kogito based on Quarkus native image
             iconClass: icon-jbpm
             tags: runtime,kogito,quarkus
             supports: quarkus
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-ubi8:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-quarkus-ubi8:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -36,18 +36,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Runtime image for Kogito based on Quarkus JVM image
             iconClass: icon-jbpm
             tags: runtime,kogito,quarkus,jvm
             supports: quarkus
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -57,18 +57,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Platform for building Kogito based on Quarkus
             iconClass: icon-jbpm
             tags: builder,kogito,quarkus
             supports: quarkus
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -78,18 +78,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Runtime image for Kogito based on SpringBoot
             iconClass: icon-jbpm
             tags: runtime,kogito,springboot
             supports: springboot
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-springboot-ubi8:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-springboot-ubi8:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -99,18 +99,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Platform for building Kogito based on Quarkus
             iconClass: icon-jbpm
             tags: builder,kogito,springboot
             supports: springboot
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -120,18 +120,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Runtime image for the Kogito Data Index Service
             iconClass: icon-jbpm
             tags: kogito,data-index
             supports: persistence backed by Infinispan server
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-data-index:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-data-index:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -141,18 +141,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Runtime image for the Kogito Jobs Service
             iconClass: icon-jbpm
             tags: kogito,jobs-service
             supports: out-of-box process timers
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-jobs-service:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-jobs-service:0.9.1
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -162,16 +162,16 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.9.1-rc2'
+        - name: '0.9.1'
           annotations:
             description: Runtime image for the Kogito Management Console
             iconClass: icon-jbpm
             tags: kogito,management-console
             supports: business process management
-            version: '0.9.1-rc2'
+            version: '0.9.1'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-management-console:0.9.1-rc2
+            name: quay.io/kiegroup/kogito-management-console:0.9.1
 

--- a/kogito-quarkus-s2i-overrides.yaml
+++ b/kogito-quarkus-s2i-overrides.yaml
@@ -53,3 +53,4 @@ packages:
 
 run:
   workdir: "/home/kogito"
+

--- a/modules/kogito-data-index/module.yaml
+++ b/modules/kogito-data-index/module.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
 name: org.kie.kogito.dataindex
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 artifacts:
   - name: kogito-data-index-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/data-index-service/0.9.1-SNAPSHOT/data-index-service-0.9.1-20200410.154951-11-runner.jar
-    md5: cf5549ad15725a3a4e69f085da56683b
+    url: https://repository.jboss.org/org/kie/kogito/data-index-service/0.9.1/data-index-service-0.9.1-runner.jar
+    md5: 3f0967d34abd163c25e88ffde45c860d
 
 execute:
   - script: configure

--- a/modules/kogito-image-dependencies/module.yaml
+++ b/modules/kogito-image-dependencies/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.image.dependencies
-version: "0.9.1-rc2"
+version: "0.9.1"
 description: holds common dependencies across images
 
 execute:

--- a/modules/kogito-infinispan-properties/module.yaml
+++ b/modules/kogito-infinispan-properties/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.infinispan.properties
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 envs:
   - name: "INFINISPAN_USEAUTH"
-    example: "false"
+    value: "false"
     description: "Flag that signals to Infinispan Hotrod client to use authentication (Used to set the infinispan.client.hotrod.use_auth system property)"
   - name: "INFINISPAN_USERNAME"
     example: "myUsername"

--- a/modules/kogito-jobs-service/module.yaml
+++ b/modules/kogito-jobs-service/module.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
 name: org.kie.kogito.jobs.service
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 artifacts:
   - name: kogito-jobs-service-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/jobs-service/0.9.1-SNAPSHOT/jobs-service-0.9.1-20200410.154450-11-runner.jar
-    md5: d7e781cbdb4b5968185699e03614a437
+    url: https://repository.jboss.org/org/kie/kogito/jobs-service/0.9.1/jobs-service-0.9.1-runner.jar
+    md5: 5045a15e32c2d50ef2b2a05ee241de7e
 
 execute:
   - script: configure

--- a/modules/kogito-jq/clean.sh
+++ b/modules/kogito-jq/clean.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 microdnf clean all
-rm -rf /var/cache/yum
+# segmentation full if delete /yum dir.
+rm -rf /var/cache/dnf

--- a/modules/kogito-jq/module.yaml
+++ b/modules/kogito-jq/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.jq
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 modules:
   install:

--- a/modules/kogito-kubernetes-client/module.yaml
+++ b/modules/kogito-kubernetes-client/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.kubernetes.client
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure

--- a/modules/kogito-launch-scripts/module.yaml
+++ b/modules/kogito-launch-scripts/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.launch.scripts
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure

--- a/modules/kogito-logging/module.yaml
+++ b/modules/kogito-logging/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.logging
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure

--- a/modules/kogito-management-console/module.yaml
+++ b/modules/kogito-management-console/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.management.console
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 envs:
   - name: "KOGITO_DATAINDEX_HTTP_URL"
@@ -8,8 +8,8 @@ envs:
 
 artifacts:
   - name: kogito-management-console-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/management-console/0.9.1-SNAPSHOT/management-console-0.9.1-20200410.155354-11-runner.jar
-    md5: afd4885e4c33884e744adaaed3e280b7
+    url: https://repository.jboss.org/org/kie/kogito/management-console/0.9.1/management-console-0.9.1-runner.jar
+    md5: 6ccb41e412ab9df7cd463ee9e9360b6d
 
 execute:
   - script: configure

--- a/modules/kogito-persistence/module.yaml
+++ b/modules/kogito-persistence/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.persistence
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 modules:
   install:

--- a/modules/kogito-quarkus-jvm/module.yaml
+++ b/modules/kogito-quarkus-jvm/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.quarkus.jvm
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure

--- a/modules/kogito-quarkus-s2i/module.yaml
+++ b/modules/kogito-quarkus-s2i/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.quarkus.s2i
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure
 
 envs:
   - name: "KOGITO_VERSION"
-    value: "0.9.1-rc2"
+    value: "0.9.1"

--- a/modules/kogito-quarkus/module.yaml
+++ b/modules/kogito-quarkus/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.quarkus
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure

--- a/modules/kogito-s2i-core/module.yaml
+++ b/modules/kogito-s2i-core/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.s2i.core
-version: '0.9.1-rc2'
+version: '0.9.1'
 description: Kogito s2i core module. All s2i files shoul be placed here.
 
 labels:

--- a/modules/kogito-springboot-s2i/module.yaml
+++ b/modules/kogito-springboot-s2i/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.springboot.s2i
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure
 
 envs:
   - name: "KOGITO_VERSION"
-    value: "0.9.1-rc2"
+    value: "0.9.1"

--- a/modules/kogito-springboot/module.yaml
+++ b/modules/kogito-springboot/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.springboot
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: configure

--- a/modules/kogito-system-user/module.yaml
+++ b/modules/kogito-system-user/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.system.user
-version: "0.9.1-rc2"
+version: "0.9.1"
 
 execute:
   - script: add-user

--- a/tests/features/kogito-quarkus-jvm-ubi8.feature
+++ b/tests/features/kogito-quarkus-jvm-ubi8.feature
@@ -33,7 +33,7 @@ Feature: Kogito-quarkus-ubi8 feature.
       | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
       | expected_phrase | ["hello","world"]        |
-    And file /home/kogito/bin/rules-quarkus-helloworld-0.9.1-SNAPSHOT-runner.jar should exist
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 
   Scenario: Verify if the binary build (forcing) is finished as expected and if it is listening on the expected port
     Given s2i build /tmp/kogito-examples/rules-quarkus-helloworld from target
@@ -50,5 +50,5 @@ Feature: Kogito-quarkus-ubi8 feature.
       | request_body    | {"strings":["hello"]}    |
       | wait            | 80                       |
       | expected_phrase | ["hello","world"]        |
-    And file /home/kogito/bin/rules-quarkus-helloworld-0.9.1-SNAPSHOT-runner.jar should exist
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 

--- a/tests/features/kogito-quarkus-ubi8-s2i.feature
+++ b/tests/features/kogito-quarkus-ubi8-s2i.feature
@@ -1,63 +1,111 @@
 @quay.io/kiegroup/kogito-quarkus-ubi8-s2i
 Feature: kogito-quarkus-ubi8-s2i image tests
 
-  Scenario: Verify if the s2i build is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
-      | variable       | value                     |
-      | LIMIT_MEMORY   | 3221225472                |
+  Scenario: Verify if the s2i build is finished as expected using native build and runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable     | value      |
+      | LIMIT_MEMORY | 3221225472 |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     |
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
-    And file /home/kogito/bin/rules-quarkus-helloworld-0.9.1-SNAPSHOT-runner should exist
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
     And file /home/kogito/ssl-libs/libsunec.so should exist
     And file /home/kogito/cacerts should exist
     And s2i build log should contain -J-Xmx2576980377
 
+  Scenario: Verify if the s2i build is finished as expected using native build and no runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.9.x
+      | variable     | value      |
+      | LIMIT_MEMORY | 3221225472 |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
+    And file /home/kogito/ssl-libs/libsunec.so should exist
+    And file /home/kogito/cacerts should exist
+    And s2i build log should contain -J-Xmx2576980377
+
+  Scenario: Verify if the s2i build is finished as expected with non native build
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.9.x
+      | variable | value |
+      | NATIVE   | false |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+    And file /home/kogito/ssl-libs/libsunec.so should exist
+    And file /home/kogito/cacerts should exist
+
   Scenario: Verify if the s2i build is finished as expected performing a non native build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-      | variable            | value                     |
-      | NATIVE              | false                     |
-      | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
+      | variable     | value                     |
+      | NATIVE       | false                     |
+      | JAVA_OPTIONS | -Dquarkus.log.level=DEBUG |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     |
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
-    And file /home/kogito/bin/rules-quarkus-helloworld-0.9.1-SNAPSHOT-runner.jar should exist
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
     And container log should contain DEBUG [io.qua.
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Dquarkus.log.level=DEBUG
 
-  Scenario: Verify if the s2i build is finished as expected performing a non native build and if it is listening on the expected port
+  Scenario: Verify if the s2i build is finished as expected performing a non native build and if it is listening on the expected port, test uses custom properties file to test the port configuration.
     Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable | value |
       | NATIVE   | false |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     |
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
-    And file /home/kogito/bin/rules-quarkus-helloworld-0.9.1-SNAPSHOT-runner.jar should exist
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+
+  Scenario: Verify if the s2i build is finished as expected performing a native build and if it is listening on the expected port, test uses custom properties file to test the port configuration.
+    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build with persistence enabled
     Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable          | value         |
       | NATIVE            | false         |
       | MAVEN_ARGS_APPEND | -Ppersistence |
-    Then file /home/kogito/bin/process-quarkus-example-0.9.1-SNAPSHOT-runner.jar should exist
+    Then file /home/kogito/bin/process-quarkus-example-runner.jar should exist
     And s2i build log should contain '/home/kogito/bin/demo.orders.proto' -> '/home/kogito/data/protobufs/demo.orders.proto'
     And s2i build log should contain '/home/kogito/bin/persons.proto' -> '/home/kogito/data/protobufs/persons.proto'
     And s2i build log should contain ---> [persistence] generating md5 for persistence files
@@ -69,43 +117,97 @@ Feature: kogito-quarkus-ubi8-s2i image tests
       | variable          | value         |
       | NATIVE            | true          |
       | MAVEN_ARGS_APPEND | -Ppersistence |
-    Then file /home/kogito/bin/process-quarkus-example-0.9.1-SNAPSHOT-runner should exist
+    Then file /home/kogito/bin/process-quarkus-example-runner should exist
     And s2i build log should contain '/home/kogito/bin/demo.orders.proto' -> '/home/kogito/data/protobufs/demo.orders.proto'
     And s2i build log should contain '/home/kogito/bin/persons.proto' -> '/home/kogito/data/protobufs/persons.proto'
     And s2i build log should contain ---> [persistence] generating md5 for persistence files
     And run sh -c 'cat /home/kogito/data/protobufs/persons-md5.txt' in container and immediately check its output for b19f6d73a0a1fea0bfbd8e2e30701d78
     And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
 
-  Scenario: Verify if the multi-module s2i build is finished as expected performing a non native build and if it is listening on the expected port
+  Scenario: Verify if the multi-module s2i build is finished as expected performing a non native build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-      | variable          | value                           |
-      | NATIVE            | false                           |
-      | ARTIFACT_DIR      | rules-quarkus-helloworld/target   |
-      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am  |
+      | variable          | value                            |
+      | NATIVE            | false                            |
+      | ARTIFACT_DIR      | rules-quarkus-helloworld/target  |
+      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     |
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
-    And file /home/kogito/bin/rules-quarkus-helloworld-0.9.1-SNAPSHOT-runner.jar should exist
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+
+  Scenario: Verify if the multi-module s2i build is finished as expected performing a native build
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable          | value                            |
+      | ARTIFACT_DIR      | rules-quarkus-helloworld/target  |
+      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
 
   Scenario: Perform a incremental s2i build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.9.x
-      | variable          | value                  |
-      | NATIVE            | false                  |
+      | variable | value |
+      | NATIVE   | false |
     Then s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+    And check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.9.x
-      | variable          | value    |
-      | NATIVE            | false    |
+      | variable | value |
+      | NATIVE   | false |
     Then s2i build log should contain Expanding artifacts from incremental build...
     And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+    And check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+
+  Scenario: Perform a third incremental s2i build, this time, with native enabled
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.9.x
+      | variable     | value      |
+      | LIMIT_MEMORY | 3221225472 |
+    Then s2i build log should contain Expanding artifacts from incremental build...
+    And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
+    And check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
 
   Scenario: verify if all labels are correctly set.
     Given image is built
@@ -132,9 +234,9 @@ Feature: kogito-quarkus-ubi8-s2i image tests
 
   Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly
     Given s2i build /tmp/kogito-examples from dmn-quarkus-example using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-      | variable          | value                           |
-      | NATIVE            | false                           |
-      | KOGITO_VERSION    | 8.0.0-SNAPSHOT                  |
+      | variable       | value          |
+      | NATIVE         | false          |
+      | KOGITO_VERSION | 8.0.0-SNAPSHOT |
     Then file /home/kogito/bin/project-1.0-SNAPSHOT-runner.jar should exist
     And check that page is served
       | property        | value                                                                                            |
@@ -146,3 +248,17 @@ Feature: kogito-quarkus-ubi8-s2i image tests
       | content_type    | application/json                                                                                 |
       | request_body    | {"Driver": {"Points": 2}, "Violation": {"Type": "speed","Actual Speed": 120,"Speed Limit": 100}} |
 
+  Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly using native build
+    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using 0.9.x and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable       | value          |
+      | KOGITO_VERSION | 8.0.0-SNAPSHOT |
+    Then file /home/kogito/bin/project-1.0-SNAPSHOT-runner should exist
+    And check that page is served
+      | property        | value                                                                                            |
+      | port            | 8080                                                                                             |
+      | path            | /Traffic%20Violation                                                                             |
+      | wait            | 80                                                                                               |
+      | expected_phrase | Should the driver be suspended?                                                                  |
+      | request_method  | POST                                                                                             |
+      | content_type    | application/json                                                                                 |
+      | request_body    | {"Driver": {"Points": 2}, "Violation": {"Type": "speed","Actual Speed": 120,"Speed Limit": 100}} |

--- a/tests/features/kogito-quarkus-ubi8.feature
+++ b/tests/features/kogito-quarkus-ubi8.feature
@@ -17,3 +17,20 @@ Feature: Kogito-quarkus-ubi8 feature.
     When container is started with command bash
     Then  file /home/kogito/ssl-libs/libsunec.so should exist
     And file /home/kogito/cacerts should exist
+
+  Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
+    Given s2i build /tmp/kogito-examples/rules-quarkus-helloworld-native/ from target
+      | variable            | value                     |
+      | NATIVE              | false                     |
+      | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
+    Then check that page is served
+      | property        | value                    |
+      | port            | 8080                     |
+      | path            | /hello                   |
+      | request_method  | POST                     |
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
+      | wait            | 80                       |
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
+

--- a/tests/features/kogito-springboot-ubi8.feature
+++ b/tests/features/kogito-springboot-ubi8.feature
@@ -29,7 +29,7 @@ Feature: springboot-quarkus-ubi8 feature.
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/process-springboot-example-0.9.1-SNAPSHOT.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
@@ -44,6 +44,6 @@ Feature: springboot-quarkus-ubi8 feature.
       | path                 | /orders/1 |
       | wait                 | 80        |
       | expected_status_code | 204       |
-    And file /home/kogito/bin/process-springboot-example-0.9.1-SNAPSHOT.jar should exist
+    And file /home/kogito/bin/process-springboot-example.jar should exist
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true

--- a/tests/test-apps/clone-repo.sh
+++ b/tests/test-apps/clone-repo.sh
@@ -11,6 +11,10 @@ git fetch origin --tags
 git fetch origin 0.9.x:0.9.x
 git checkout 0.9.x
 
+# make a new copy of rules-quarkus-helloworld for native tests
+cp -rv  /tmp/kogito-examples/rules-quarkus-helloworld/ /tmp/kogito-examples/rules-quarkus-helloworld-native/
+mvn -f rules-quarkus-helloworld-native -Pnative clean package -DskipTests
+
 # generating the app binaries to test the binary build
 mvn -f rules-quarkus-helloworld clean package -DskipTests
 mvn -f process-springboot-example clean package -DskipTests
@@ -20,11 +24,15 @@ cp /tmp/kogito-examples/dmn-quarkus-example/src/main/resources/* /tmp/kogito-exa
 rm -rf /tmp/kogito-examples/dmn-quarkus-example/src
 rm -rf /tmp/kogito-examples/dmn-quarkus-example/pom.xml
 
-# by adding the application.properties file telling quarkus to start on
+# by adding the application.properties file telling app to start on
 # port 10000, the purpose of this tests is make sure that the images
 # will ensure the use of the port 8080.
-cp ${TEST_DIR}/application.properties kogito-examples/rules-quarkus-helloworld/src/main/resources/META-INF/
+cp ${TEST_DIR}/application.properties /tmp/kogito-examples/rules-quarkus-helloworld/src/main/resources/META-INF/
+# exit if this script has failed to copy the application properties to the expected place.
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+(echo ""; echo "server.port=10000") >> /tmp/kogito-examples/process-springboot-example/src/main/resources/application.properties
 
-cd rules-quarkus-helloworld
 git add --all  :/
 git commit -am "test"


### PR DESCRIPTION
staging data-index: data-index-service-0.9.1-runner.jar
md5: 805fed350dbeb03b699e1bf99374d64f

staging jobs-service: jobs-service-0.9.1-runner.jar
md5: 72cf21f32a3777f59beaf0994026ee59

staging management-console: management-console-0.9.1-runner.jar
md5: ceb538a8ef0a30efd26a422cab9f5f94

images available on quay.io under tag 0.9.1-rc3:
- quay.io/kiegroup/kogito-data-index:0.9.1-rc3
- quay.io/kiegroup/kogito-jobs-service:0.9.1-rc3
- quay.io/kiegroup/kogito-management-console:0.9.1-rc3
- quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.9.1-rc3
- quay.io/kiegroup/kogito-quarkus-ubi8:0.9.1-rc3
- quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.9.1-rc3
- quay.io/kiegroup/kogito-springboot-ubi8:0.9.1-rc3
- quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.9.1-rc3

Signed-off-by: spolti <fspolti@redhat.com>