### PR TITLE
[0.9.x][KOGITO-1909] - Behave tests on Kogito images fails when non n…

### DIFF
--- a/kogito-quarkus-s2i-overrides.yaml
+++ b/kogito-quarkus-s2i-overrides.yaml
@@ -51,3 +51,5 @@ packages:
   - glibc-devel
   - zlib-devel
 
+run:
+  workdir: "/home/kogito"


### PR DESCRIPTION
…ative build and no runtime image is used

Fixes Caused by: java.nio.file.AccessDeniedException: ./proc/tty/driver
when running behave tests with non native builds and no runtime image, try the example directly on the buider image.

cherry-picked from: https://github.com/kiegroup/kogito-images/pull/143

Signed-off-by: spolti <fspolti@redhat.com>