### PR TITLE
[KOGITO-1945] Release Kogito Images 0.10.0

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 name: "kogito-image-real-name-on-overrides-file"
-version: "0.10.0-rc1"
+version: "0.10.0"
 # until this issue is not fixed use 8.0 tag.
 # https://github.com/rpm-software-management/microdnf/issues/50
 # https://bugzilla.redhat.com/show_bug.cgi?id=1769831

--- a/kogito-imagestream.yaml
+++ b/kogito-imagestream.yaml
@@ -15,18 +15,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Runtime image for Kogito based on Quarkus native image
             iconClass: icon-jbpm
             tags: runtime,kogito,quarkus
             supports: quarkus
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-ubi8:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-quarkus-ubi8:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -36,18 +36,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Runtime image for Kogito based on Quarkus JVM image
             iconClass: icon-jbpm
             tags: runtime,kogito,quarkus,jvm
             supports: quarkus
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -57,18 +57,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Platform for building Kogito based on Quarkus
             iconClass: icon-jbpm
             tags: builder,kogito,quarkus
             supports: quarkus
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -78,18 +78,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Runtime image for Kogito based on SpringBoot
             iconClass: icon-jbpm
             tags: runtime,kogito,springboot
             supports: springboot
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-springboot-ubi8:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-springboot-ubi8:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -99,18 +99,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Platform for building Kogito based on Quarkus
             iconClass: icon-jbpm
             tags: builder,kogito,springboot
             supports: springboot
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -120,18 +120,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Runtime image for the Kogito Data Index Service
             iconClass: icon-jbpm
             tags: kogito,data-index
             supports: persistence backed by Infinispan server
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-data-index:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-data-index:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -141,18 +141,18 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Runtime image for the Kogito Jobs Service
             iconClass: icon-jbpm
             tags: kogito,jobs-service
             supports: out-of-box process timers
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-jobs-service:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-jobs-service:0.10.0
   - kind: ImageStream
     apiVersion: v1
     metadata:
@@ -162,16 +162,16 @@ items:
         openshift.io/provider-display-name: Kie Group.
     spec:
       tags:
-        - name: '0.10.0-rc1'
+        - name: '0.10.0'
           annotations:
             description: Runtime image for the Kogito Management Console
             iconClass: icon-jbpm
             tags: kogito,management-console
             supports: business process management
-            version: '0.10.0-rc1'
+            version: '0.10.0'
           referencePolicy:
             type: Local
           from:
             kind: DockerImage
-            name: quay.io/kiegroup/kogito-management-console:0.10.0-rc1
+            name: quay.io/kiegroup/kogito-management-console:0.10.0
 

--- a/modules/kogito-data-index/module.yaml
+++ b/modules/kogito-data-index/module.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
 name: org.kie.kogito.dataindex
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 artifacts:
   - name: kogito-data-index-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/data-index-service/8.0.0-SNAPSHOT/data-index-service-8.0.0-20200408.070316-207-runner.jar
-    md5: 9272617dfec4ff548603319250b8ed87
+    url: https://repository.jboss.org/org/kie/kogito/data-index-service/0.10.0/data-index-service-0.10.0-runner.jar
+    md5: 989299a600c47695153f791cc9acdb14
 
 execute:
   - script: configure

--- a/modules/kogito-image-dependencies/module.yaml
+++ b/modules/kogito-image-dependencies/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.image.dependencies
-version: "0.10.0-rc1"
+version: "0.10.0"
 description: holds common dependencies across images
 
 execute:

--- a/modules/kogito-infinispan-properties/module.yaml
+++ b/modules/kogito-infinispan-properties/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.infinispan.properties
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 envs:
   - name: "INFINISPAN_USEAUTH"

--- a/modules/kogito-jobs-service/module.yaml
+++ b/modules/kogito-jobs-service/module.yaml
@@ -1,11 +1,11 @@
 schema_version: 1
 name: org.kie.kogito.jobs.service
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 artifacts:
   - name: kogito-jobs-service-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/jobs-service/8.0.0-SNAPSHOT/jobs-service-8.0.0-20200408.070024-132-runner.jar
-    md5: 72ffb4a158d4b90a68fe080cfb28c3ad
+    url: https://repository.jboss.org/org/kie/kogito/jobs-service/0.10.0/jobs-service-0.10.0-runner.jar
+    md5: 71619ecd10e9ff63b47e2c6af8081488
 
 execute:
   - script: configure

--- a/modules/kogito-jq/module.yaml
+++ b/modules/kogito-jq/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.jq
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 modules:
   install:

--- a/modules/kogito-kubernetes-client/module.yaml
+++ b/modules/kogito-kubernetes-client/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.kubernetes.client
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure

--- a/modules/kogito-launch-scripts/module.yaml
+++ b/modules/kogito-launch-scripts/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.launch.scripts
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure

--- a/modules/kogito-logging/module.yaml
+++ b/modules/kogito-logging/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.logging
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure

--- a/modules/kogito-management-console/module.yaml
+++ b/modules/kogito-management-console/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.management.console
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 envs:
   - name: "KOGITO_DATAINDEX_HTTP_URL"
@@ -8,8 +8,8 @@ envs:
 
 artifacts:
   - name: kogito-management-console-runner.jar
-    url: https://repository.jboss.org/org/kie/kogito/management-console/8.0.0-SNAPSHOT/management-console-8.0.0-20200408.070632-43-runner.jar
-    md5: c8519cc20f283b671c6da064e7bf0326
+    url: https://repository.jboss.org/org/kie/kogito/management-console/0.10.0/management-console-0.10.0-runner.jar
+    md5: b46184831948061b64fbe37e0c158400
 
 execute:
   - script: configure

--- a/modules/kogito-persistence/module.yaml
+++ b/modules/kogito-persistence/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.persistence
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 modules:
   install:

--- a/modules/kogito-quarkus-jvm/module.yaml
+++ b/modules/kogito-quarkus-jvm/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.quarkus.jvm
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure

--- a/modules/kogito-quarkus-s2i/module.yaml
+++ b/modules/kogito-quarkus-s2i/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.quarkus.s2i
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure
 
 envs:
   - name: "KOGITO_VERSION"
-    value: "0.10.0-rc1"
+    value: "0.10.0"

--- a/modules/kogito-quarkus/module.yaml
+++ b/modules/kogito-quarkus/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.quarkus
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure

--- a/modules/kogito-s2i-core/module.yaml
+++ b/modules/kogito-s2i-core/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.s2i.core
-version: '0.10.0-rc1'
+version: '0.10.0'
 description: Kogito s2i core module. All s2i files shoul be placed here.
 
 labels:

--- a/modules/kogito-springboot-s2i/module.yaml
+++ b/modules/kogito-springboot-s2i/module.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 name: org.kie.kogito.springboot.s2i
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure
 
 envs:
   - name: "KOGITO_VERSION"
-    value: "0.10.0-rc1"
+    value: "0.10.0"

--- a/modules/kogito-springboot/module.yaml
+++ b/modules/kogito-springboot/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.springboot
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: configure

--- a/modules/kogito-system-user/module.yaml
+++ b/modules/kogito-system-user/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: org.kie.kogito.system.user
-version: "0.10.0-rc1"
+version: "0.10.0"
 
 execute:
   - script: add-user

--- a/tests/features/kogito-quarkus-ubi8-s2i.feature
+++ b/tests/features/kogito-quarkus-ubi8-s2i.feature
@@ -2,7 +2,7 @@
 Feature: kogito-quarkus-ubi8-s2i image tests
 
   Scenario: Verify if the s2i build is finished as expected using native build and runtime image
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable     | value      |
       | NATIVE       | true       |
       | LIMIT_MEMORY | 3221225472 |
@@ -21,7 +21,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And s2i build log should contain -J-Xmx2576980377
 
   Scenario: Verify if the s2i build is finished as expected using native build and no runtime image
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.10.0
       | variable     | value      |
       | NATIVE       | true       |
       | LIMIT_MEMORY | 3221225472 |
@@ -40,7 +40,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And s2i build log should contain -J-Xmx2576980377
 
   Scenario: Verify if the s2i build is finished as expected with non native build and no runtime image
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.10.0
       | variable | value |
       | NATIVE   | false |
     Then check that page is served
@@ -57,7 +57,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And file /home/kogito/cacerts should exist
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build with runtime image
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable     | value                     |
       | NATIVE       | false                     |
       | JAVA_OPTIONS | -Dquarkus.log.level=DEBUG |
@@ -75,7 +75,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Dquarkus.log.level=DEBUG
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build and if it is listening on the expected port , test uses custom properties file to test the port configuration.
-    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable | value |
       | NATIVE   | false |
     Then check that page is served
@@ -90,7 +90,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 
   Scenario: Verify if the s2i build is finished as expected performing a native build and if it is listening on the expected port, test uses custom properties file to test the port configuration.
-    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable     | value      |
       | NATIVE       | true       |
       | LIMIT_MEMORY | 6442450944 |
@@ -106,7 +106,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build with persistence enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable          | value         |
       | NATIVE            | false         |
       | MAVEN_ARGS_APPEND | -Ppersistence |
@@ -120,7 +120,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
   # ignore until https://issues.redhat.com/browse/KOGITO-2003 is not fixed.
   @ignore
   Scenario: Verify if the s2i build is finished as expected performing a native build with persistence enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable          | value         |
       | NATIVE            | true          |
       | LIMIT_MEMORY      | 6442450944    |
@@ -133,7 +133,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And s2i build log should contain ---> [persistence] generating md5 for persistence files
 
   Scenario: Scenario: Verify if the multi-module s2i build is finished as expected performing a non native build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable          | value                            |
       | NATIVE            | false                            |
       | ARTIFACT_DIR      | rules-quarkus-helloworld/target  |
@@ -150,7 +150,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
 
   Scenario: Verify if the multi-module s2i build is finished as expected performing a native build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable          | value                            |
       | NATIVE            | true                             |
       | LIMIT_MEMORY      | 6442450944                       |
@@ -168,7 +168,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
 
   Scenario: Perform a incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.10.0
       | variable | value |
       | NATIVE   | false |
     Then s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
@@ -185,7 +185,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.10.0
       | variable | value |
       | NATIVE   | false |
     Then s2i build log should contain Expanding artifacts from incremental build...
@@ -202,7 +202,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
       | expected_phrase | ["hello","world"]     |
 
   Scenario: Perform a third incremental s2i build, this time, with native enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using 0.10.0
       | variable     | value      |
       | NATIVE       | true       |
       | LIMIT_MEMORY | 6442450944 |
@@ -243,7 +243,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And run sh -c 'echo $GRAALVM_VERSION' in container and immediately check its output for 19.3.1
 
   Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly
-    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable       | value          |
       | NATIVE         | false          |
       | KOGITO_VERSION | 8.0.0-SNAPSHOT |
@@ -259,7 +259,7 @@ Feature: kogito-quarkus-ubi8-s2i image tests
       | request_body    | {"Driver": {"Points": 2}, "Violation": {"Type": "speed","Actual Speed": 120,"Speed Limit": 100}} |
 
   Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly using native build
-    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable       | value          |
       | NATIVE         | true           |
       | LIMIT_MEMORY   | 6442450944     |

--- a/tests/features/kogito-springboot-ubi8-s2i.feature
+++ b/tests/features/kogito-springboot-ubi8-s2i.feature
@@ -2,7 +2,7 @@
 Feature: kogito-springboot-ubi8-s2i image tests
 
   Scenario: Verify if the s2i build is finished as expected with debug enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
       | variable     | value        |
       | JAVA_OPTIONS | -Ddebug=true |
     Then check that page is served
@@ -16,7 +16,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
   Scenario: Verify if the s2i build is finished as expected with no runtime image and debug enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using 0.10.0
       | variable            | value        |
       | JAVA_OPTIONS        | -Ddebug=true |
     Then check that page is served
@@ -30,7 +30,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
   Scenario: Verify if the s2i build is finished as expected and if it is listening on the expected port, test uses custom properties file to test the port configuration.
-    Given s2i build /tmp/kogito-examples from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+    Given s2i build /tmp/kogito-examples from process-springboot-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |
@@ -41,7 +41,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
     And container log should contain Tomcat initialized with port(s): 8080 (http)
 
   Scenario: Verify if the s2i build is finished as expected with persistence enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using 0.10.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
       | variable          | value         |
       | MAVEN_ARGS_APPEND | -Ppersistence |
     Then file /home/kogito/bin/process-springboot-example.jar should exist
@@ -52,7 +52,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
     And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
 
   Scenario: Verify if the s2i build is finished as expected using multi-module build with debug enabled
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using 0.10.0 and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
       | variable          | value                              |
       | JAVA_OPTIONS      | -Ddebug=true                       |
       | ARTIFACT_DIR      | process-springboot-example/target  |
@@ -68,7 +68,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
   Scenario: Scenario: Perform a incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using 0.10.0
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |
@@ -79,7 +79,7 @@ Feature: kogito-springboot-ubi8-s2i image tests
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using master
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using 0.10.0
     Then s2i build log should contain Expanding artifacts from incremental build...
     And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
 

--- a/tests/test-apps/clone-repo.sh
+++ b/tests/test-apps/clone-repo.sh
@@ -11,7 +11,7 @@ rm -rf kogito-examples/
 git clone https://github.com/kiegroup/kogito-examples.git
 cd kogito-examples/
 git fetch origin --tags
-git checkout master
+git checkout -b 0.10.0 0.10.0
 
 # make a new copy of rules-quarkus-helloworld for native tests
 cp -rv  /tmp/kogito-examples/rules-quarkus-helloworld/ /tmp/kogito-examples/rules-quarkus-helloworld-native/


### PR DESCRIPTION
staging data-index: data-index-service-0.10.0-runner.jar
md5: 989299a600c47695153f791cc9acdb14

staging jobs-service: jobs-service-0.10.0-runner.jar
md5: 71619ecd10e9ff63b47e2c6af8081488

staging management-console: management-console-0.10.0-runner.jar
md5: b46184831948061b64fbe37e0c158400

images to be available in a few hours on quay.io under tag 0.10.0-rc2:
- quay.io/kiegroup/kogito-data-index:0.10.0-rc2
- quay.io/kiegroup/kogito-jobs-service:0.10.0-rc2
- quay.io/kiegroup/kogito-management-console:0.10.0-rc2
- quay.io/kiegroup/kogito-quarkus-jvm-ubi8:0.10.0-rc2
- quay.io/kiegroup/kogito-quarkus-ubi8:0.10.0-rc2
- quay.io/kiegroup/kogito-quarkus-ubi8-s2i:0.10.0-rc2
- quay.io/kiegroup/kogito-springboot-ubi8:0.10.0-rc2
- quay.io/kiegroup/kogito-springboot-ubi8-s2i:0.10.0-rc2