### PR TITLE
[KOGITO-1672] - Improve Kogito Images Behave tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,25 +6,60 @@ pipeline{
                 sh "docker rmi -f \$(docker images -q) || date"
             }
         }
-        stage('Build'){
+        stage('Prepare offline kogito-examples'){
             steps{
-                sh "make build"
+                sh "make clone-repos"
             }
         }
-        stage('Test'){
+        stage('Build and test kogito-quarkus-ubi8 image'){
             steps{
-                sh "make test"
+                sh "make kogito-quarkus-ubi8"
             }
-            post{
-                always{
-                    junit 'target/test/results/*.xml'
-                }
+        }
+        stage('Build and test kogito-quarkus-jvm-ubi8 image'){
+            steps{
+                sh "make kogito-quarkus-jvm-ubi8"
+            }
+        }
+        stage('Build and test kogito-quarkus-ubi8-s2i image'){
+            steps{
+                sh "make kogito-quarkus-ubi8-s2i"
+            }
+        }
+        stage('Build and test kogito-springboot-ubi8 image'){
+            steps{
+                sh "make kogito-springboot-ubi8"
+            }
+        }
+        stage('Build and test kogito-springboot-ubi8-s2i image '){
+            steps{
+                sh "make kogito-springboot-ubi8-s2i"
+            }
+        }
+        stage('Build and test kogito-data-index image '){
+            steps{
+                sh "make kogito-data-index"
+            }
+        }
+        stage('Build and test kogito-jobs-service image '){
+            steps{
+                sh "make kogito-jobs-service"
+            }
+        }
+        stage('Build and test kogito-management-console image '){
+            steps{
+                sh "make kogito-management-console"
             }
         }
         stage('Finishing'){
             steps{
                 sh "docker rmi -f \$(docker images -q) || date"
             }
+        }
+    }
+    post{
+        always{
+            junit 'target/test/results/*.xml'
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -3,70 +3,121 @@ SHORTENED_LATEST_VERSION := $(shell echo $(IMAGE_VERSION) | awk -F. '{print $$1"
 BUILD_ENGINE := docker
 .DEFAULT_GOAL := build
 
+
 # Build all images
 .PHONY: build
-build: kogito-quarkus-ubi8 kogito-quarkus-jvm-ubi8 kogito-quarkus-ubi8-s2i kogito-springboot-ubi8 kogito-springboot-ubi8-s2i kogito-data-index kogito-jobs-service kogito-management-console
+# start to build the images
+build: clone-repos kogito-quarkus-ubi8 kogito-quarkus-jvm-ubi8 kogito-quarkus-ubi8-s2i kogito-springboot-ubi8 kogito-springboot-ubi8-s2i kogito-data-index kogito-jobs-service kogito-management-console
 
+clone-repos:
+# if the NO_TEST env defined, proceed with the tests, as first step prepare the repo to be used
+ifneq ($(ignore_test),true)
+	cd tests/test-apps && sh clone-repo.sh
+endif
+
+# build the quay.io/kiegroup/kogito-quarkus-ubi8 image
 kogito-quarkus-ubi8:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-quarkus-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-quarkus-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)),rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-quarkus-ubi8:${IMAGE_VERSION} quay.io/kiegroup/kogito-quarkus-ubi8:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-quarkus-jvm-ubi8 image
 kogito-quarkus-jvm-ubi8:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-quarkus-jvm-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if no NO_TEST env defined, test the image
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-quarkus-jvm-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)),rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-quarkus-jvm-ubi8:${IMAGE_VERSION} quay.io/kiegroup/kogito-quarkus-jvm-ubi8:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-quarkus-ubi8-s2i image
 kogito-quarkus-ubi8-s2i:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-quarkus-s2i-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-quarkus-s2i-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)),rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-quarkus-ubi8-s2i:${IMAGE_VERSION} quay.io/kiegroup/kogito-quarkus-ubi8-s2i:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-springboot-ubi8 image
 kogito-springboot-ubi8:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-springboot-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-springboot-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)),rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-springboot-ubi8:${IMAGE_VERSION} quay.io/kiegroup/kogito-springboot-ubi8:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-springboot-ubi8-s2i image
 kogito-springboot-ubi8-s2i:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-springboot-s2i-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-springboot-s2i-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-springboot-ubi8-s2i:${IMAGE_VERSION} quay.io/kiegroup/kogito-springboot-ubi8-s2i:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-data-index image
 kogito-data-index:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-data-index-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-data-index-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-data-index:${IMAGE_VERSION} quay.io/kiegroup/kogito-data-index:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-jobs-service image
 kogito-jobs-service:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-jobs-service-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-jobs-service-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-jobs-service:${IMAGE_VERSION} quay.io/kiegroup/kogito-jobs-service:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-management-console image
 kogito-management-console:
+ifneq ($(ignore_build),true)
 	cekit -v build --overrides-file kogito-management-console-overrides.yaml ${BUILD_ENGINE}
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	cekit -v test --overrides-file kogito-management-console-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-management-console:${IMAGE_VERSION} quay.io/kiegroup/kogito-management-console:${SHORTENED_LATEST_VERSION}
 endif
-
-# Build and test all images
-.PHONY: test
-test:
-	cd tests/test-apps && sh clone-repo.sh
-	cekit -v test --overrides-file kogito-quarkus-overrides.yaml behave
-	cekit -v test --overrides-file kogito-quarkus-jvm-overrides.yaml behave
-	cekit -v test --overrides-file kogito-quarkus-s2i-overrides.yaml behave
-	cekit -v test --overrides-file kogito-springboot-overrides.yaml behave
-	cekit -v test --overrides-file kogito-springboot-s2i-overrides.yaml behave
-	cekit -v test --overrides-file kogito-data-index-overrides.yaml behave
-	cekit -v test --overrides-file kogito-jobs-service-overrides.yaml behave
-	cekit -v test --overrides-file kogito-management-console-overrides.yaml behave
 
 
 # push images to quay.io, this requires permissions under kiegroup organization
@@ -89,7 +140,7 @@ _push:
 	docker push quay.io/kiegroup/kogito-jobs-service:latest
 	docker push quay.io/kiegroup/kogito-management-console:${IMAGE_VERSION}
 	docker push quay.io/kiegroup/kogito-management-console:latest
-ifneq ($(findstring "rc",$(IMAGE_VERSION)),"rc")
+ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	@echo "${SHORTENED_LATEST_VERSION} will be pushed"
 	docker push quay.io/kiegroup/kogito-quarkus-ubi8:${SHORTENED_LATEST_VERSION}
 	docker push quay.io/kiegroup/kogito-quarkus-jvm-ubi8:${SHORTENED_LATEST_VERSION}
@@ -107,6 +158,7 @@ endif
 push-staging: build _push-staging
 _push-staging:
 	python3 scripts/push-staging.py
+
 
 # push to local registry, useful to push the built images to local registry
 # requires parameter: REGISTRY: my-custom-registry:[port]

--- a/README.md
+++ b/README.md
@@ -825,12 +825,21 @@ Before proceed please make sure you have checked the [requirements](#kogito-imag
 To build the images for local testing there is a [Makefile](./Makefile) which will do all the hard work for you.
 With this Makefile you can:
 
-- Build all images with only one command
+- Build and test all images with only one command:
      ```bash
      $ make
      ```
-     
-- Build images individually
+     If there's no need to run the tests just set the *ignore_test* env to true, e.g.:
+     ```bash
+     $ make ignore_test=true
+     ```
+
+- Test all images with only one command, no build triggered, set the *ignore_build* env to true, e.g.:
+     ```bash
+     $ make ignore_build=true
+     ```
+ 
+- Build images individually, by default it will build and test each image
      ```bash
      $ make kogito-quarkus-ubi8
      $ make kogito-quarkus-jvm-ubi8
@@ -841,6 +850,17 @@ With this Makefile you can:
      $ make kogito-jobs-service 
      $ make kogito-management-console
      ```
+  
+     We can ignore the build or the tests while interacting with a specific image as well, to build only:
+     ```bash
+     $ make ignore_test=true {image_name}
+
+     ```
+     
+     Or to test only:
+     ```bash
+     $ make ignore_build=true {image_name}
+     ```      
      
 - Build and Push the Images to quay or a repo for you preference, for this you need to edit the Makefile accordingly: 
       ```bash
@@ -857,6 +877,12 @@ With this Makefile you can:
       ```
       It uses the [push-staging.py](scripts/push-staging.py) script to handle the images.
 
+- Push images to a local registry for testing 
+      ```bash
+      $ make push-local-registry REGISTRY=docker-registry-default.apps.spolti.cloud NS=spolti-1
+      ```
+      It uses the [push-local-registry.sh](scripts/push-local-registry.sh) script properly tag the images and push to the
+      desired registry.
 
 #### Image Modules
 

--- a/modules/kogito-data-index/tests/bats/kogito-data-index.bats
+++ b/modules/kogito-data-index/tests/bats/kogito-data-index.bats
@@ -23,12 +23,11 @@ function clear_vars() {
 
 @test "check if infinispan properties is blank" {
     clear_vars
-    local expected=""
+    local expected=" -Dquarkus.infinispan-client.use-auth=false"
     configure_infinispan_props
     echo "Result is ${INFINISPAN_PROPERTIES} and expected is ${expected}" >&2
     [ "${expected}" = "${INFINISPAN_PROPERTIES}" ]
 }
-
 
 @test "check if infinispan auth is false" {
     clear_vars

--- a/modules/kogito-infinispan-properties/added/kogito-infinispan-properties.sh
+++ b/modules/kogito-infinispan-properties/added/kogito-infinispan-properties.sh
@@ -23,12 +23,11 @@ function configure_infinispan_props() {
         exit 1
     fi
 
-    if [ -z "${INFINISPAN_USERNAME}" ]; then
-        if [ ! -z "${INFINISPAN_USEAUTH}" ]; then
-            INFINISPAN_USEAUTH="false"
-        fi
+    # default to false if empty or any value different than true or false.
+    if  [ -z "${INFINISPAN_USEAUTH}" ] || [[ ! ${INFINISPAN_USEAUTH^^} =~ FALSE$|TRUE$ ]]; then
+        INFINISPAN_USEAUTH="false"
     fi
- 
+
     if [ ! -z "${INFINISPAN_USERNAME}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.auth-username=${INFINISPAN_USERNAME}"); INFINISPAN_USEAUTH="true"; fi
     if [ ! -z "${INFINISPAN_PASSWORD}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.auth-password=${INFINISPAN_PASSWORD}"); fi
     if [ ! -z "${INFINISPAN_USEAUTH}" ]; then infinispan_props=$(echo "${infinispan_props} -Dquarkus.infinispan-client.use-auth=${INFINISPAN_USEAUTH}"); fi

--- a/modules/kogito-infinispan-properties/module.yaml
+++ b/modules/kogito-infinispan-properties/module.yaml
@@ -5,7 +5,7 @@ version: "0.10.0-rc1"
 envs:
   - name: "INFINISPAN_USEAUTH"
     example: "false"
-    description: "Flag that signals to Infinispan Hotrod client to use authentication (Used to set the infinispan.client.hotrod.use_auth system property)"
+    description: "Flag that signals to Infinispan Hotrod client to use authentication (Used to set the infinispan.client.hotrod.use_auth system property). Defaults to false"
   - name: "INFINISPAN_USERNAME"
     example: "myUsername"
     description: "Username for the user credential used by the Hotrod client (Used to set the infinispan.client.hotrod.auth_username system property)"

--- a/modules/kogito-infinispan-properties/tests/bats/kogito-infinispan-properties.bats
+++ b/modules/kogito-infinispan-properties/tests/bats/kogito-infinispan-properties.bats
@@ -15,13 +15,12 @@ function clear_vars() {
 
 @test "check if infinispan properties is blank" {
     clear_vars
-    local expected=""
+    local expected=" -Dquarkus.infinispan-client.use-auth=false"
     configure_infinispan_props
 
     echo "Result is ${INFINISPAN_PROPERTIES} and expected is ${expected}" >&2
     [ "${expected}" = "${INFINISPAN_PROPERTIES}" ]
 }
-
 
 @test "check if infinispan auth is false" {
     clear_vars
@@ -91,3 +90,4 @@ function clear_vars() {
     echo "Status: ${status}"
     [ "$status" -eq 1 ]
 }
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,14 @@ Its usage is pretty simple, only one parameter is accepted:
 $ python manage-kogito-version.py --bump-to 1.0.0  
 ```
 
+The script also allows you to set a custom branch for the kogito-examples repository on the behave tests. Useful for minor
+releases, e.g. 0.9.x branch.
+
+```bash
+$ python manage-kogito-version.py --bump-to 0.10.1-rc1 --apps-branch 0.10.x
+```
+
+
 The command above will update all the needed files to the version 1.0.0. These changes includes updates on
 
  - all cekit modules

--- a/tests/features/common.feature
+++ b/tests/features/common.feature
@@ -1,5 +1,4 @@
 @quay.io/kiegroup/kogito-springboot-ubi8-s2i @quay.io/kiegroup/kogito-springboot-ubi8 @quay.io/kiegroup/kogito-quarkus-ubi8-s2i @quay.io/kiegroup/kogito-quarkus-ubi8 @quay.io/kiegroup/kogito-quarkus-jvm-ubi8 @quay.io/kiegroup/kiegroup/kogito-data-index
-
 Feature: Common tests for Kogito images
 
   Scenario: Verify if Kogito user is correctly configured

--- a/tests/features/kogito-data-index.feature
+++ b/tests/features/kogito-data-index.feature
@@ -1,5 +1,4 @@
 @quay.io/kiegroup/kogito-data-index
-
 Feature: Kogito-data-index feature.
 
   Scenario: verify if all labels are correctly set.
@@ -69,3 +68,4 @@ Feature: Kogito-data-index feature.
       | INFINISPAN_USEAUTH              | true                   |
       | INFINISPAN_SASLMECHANISM        | PLAIN                  |
      Then container log should not contain Error: Could not find or load main class [ERROR]
+

--- a/tests/features/kogito-jobs-service.feature
+++ b/tests/features/kogito-jobs-service.feature
@@ -1,16 +1,15 @@
 @quay.io/kiegroup/kogito-jobs-service
-
 Feature: Kogito-jobs-service feature.
 
   Scenario: verify if all labels are correctly set.
     Given image is built
-     Then the image should contain label maintainer with value kogito <kogito@kiegroup.com>
-     And the image should contain label io.openshift.s2i.scripts-url with value image:///usr/local/s2i
-     And the image should contain label io.openshift.s2i.destination with value /tmp
-     And the image should contain label io.openshift.expose-services with value 8080:http
-     And the image should contain label io.k8s.description with value Runtime image for Kogito Jobs Service
-     And the image should contain label io.k8s.display-name with value Kogito Jobs Service
-     And the image should contain label io.openshift.tags with value kogito,jobs-service
+    Then the image should contain label maintainer with value kogito <kogito@kiegroup.com>
+    And the image should contain label io.openshift.s2i.scripts-url with value image:///usr/local/s2i
+    And the image should contain label io.openshift.s2i.destination with value /tmp
+    And the image should contain label io.openshift.expose-services with value 8080:http
+    And the image should contain label io.k8s.description with value Runtime image for Kogito Jobs Service
+    And the image should contain label io.k8s.display-name with value Kogito Jobs Service
+    And the image should contain label io.openshift.tags with value kogito,jobs-service
 
   Scenario: verify if the jobs service binary is available on /home/kogito/bin
     When container is started with command bash
@@ -21,12 +20,14 @@ Feature: Kogito-jobs-service feature.
       | variable     | value |
       | SCRIPT_DEBUG | true  |
     Then container log should contain + exec java -XshowSettings:properties -Dquarkus.infinispan-client.use-auth=false -jar /home/kogito/bin/kogito-jobs-service-runner.jar
+    And container log should contain started in
+    And container log should not contain Application failed to start
 
   Scenario: verify if container fails if persistence is enabled but there is no infinispan server list.
     When container is started with env
-      | variable            | value |
-      | ENABLE_PERSISTENCE  | true  |
-     Then container log should contain INFINISPAN_CLIENT_SERVER_LIST env not found, please set it.
+      | variable           | value |
+      | ENABLE_PERSISTENCE | true  |
+    Then container log should contain INFINISPAN_CLIENT_SERVER_LIST env not found, please set it.
 
   Scenario: verify if the persistence is correctly enabled without auth
     When container is started with env
@@ -35,7 +36,9 @@ Feature: Kogito-jobs-service feature.
       | ENABLE_PERSISTENCE            | true            |
       | INFINISPAN_CLIENT_SERVER_LIST | localhost:11111 |
     Then container log should contain quarkus.infinispan-client.server-list = localhost:11111
-     And container log should contain quarkus.infinispan-client.use-auth = false
+    And container log should contain quarkus.infinispan-client.use-auth = false
+    And container log should contain started in
+    And container log should not contain Application failed to start
 
   Scenario: verify if auth is correctly set
     When container is started with env
@@ -47,9 +50,11 @@ Feature: Kogito-jobs-service feature.
       | INFINISPAN_USERNAME           | IamNotExist     |
       | INFINISPAN_PASSWORD           | hard2guess      |
     Then container log should contain quarkus.infinispan-client.use-auth = true
-     And container log should contain quarkus.infinispan-client.auth-password = hard2guess
-     And container log should contain quarkus.infinispan-client.auth-username = IamNotExist
-     And container log should contain quarkus.infinispan-client.server-list = localhost:11111
+    And container log should contain quarkus.infinispan-client.auth-password = hard2guess
+    And container log should contain quarkus.infinispan-client.auth-username = IamNotExist
+    And container log should contain quarkus.infinispan-client.server-list = localhost:11111
+    And container log should contain started in
+    And container log should not contain Application failed to start
 
   Scenario: verify if all parameters are correctly set
     When container is started with env
@@ -63,24 +68,27 @@ Feature: Kogito-jobs-service feature.
       | INFINISPAN_AUTHREALM          | SecretRealm     |
       | INFINISPAN_SASLMECHANISM      | COOLGSSAPI      |
     Then container log should contain quarkus.infinispan-client.use-auth = true
-     And container log should contain quarkus.infinispan-client.auth-password = hard2guess
-     And container log should contain quarkus.infinispan-client.auth-username = IamNotExist
-     And container log should contain quarkus.infinispan-client.auth-realm = SecretRealm
-     And container log should contain quarkus.infinispan-client.sasl-mechanism = COOLGSSAPI
-     And container log should contain quarkus.infinispan-client.server-list = localhost:11111
+    And container log should contain quarkus.infinispan-client.auth-password = hard2guess
+    And container log should contain quarkus.infinispan-client.auth-username = IamNotExist
+    And container log should contain quarkus.infinispan-client.auth-realm = SecretRealm
+    And container log should contain quarkus.infinispan-client.sasl-mechanism = COOLGSSAPI
+    And container log should contain quarkus.infinispan-client.server-list = localhost:11111
+    And container log should contain started in
+    And container log should not contain Application failed to start
 
   Scenario: verify if container fails if event is enabled but there is no Kafka bootstrap server set.
     When container is started with env
-      | variable            | value |
-      | ENABLE_EVENTS       | true  |
-     Then container log should contain KAFKA_BOOTSTRAP_SERVERS env not found, please set it.
-    
-     @ignore
+      | variable      | value |
+      | ENABLE_EVENTS | true  |
+    Then container log should contain KAFKA_BOOTSTRAP_SERVERS env not found, please set it.
+
   Scenario: verify if the events is correctly enabled
     When container is started with env
-      | variable                      | value           |
-      | SCRIPT_DEBUG                  | true            |
-      | ENABLE_EVENTS                 | true            |
-      | KAFKA_BOOTSTRAP_SERVERS       | localhost:11111 |
+      | variable                | value           |
+      | SCRIPT_DEBUG            | true            |
+      | ENABLE_EVENTS           | true            |
+      | KAFKA_BOOTSTRAP_SERVERS | localhost:11111 |
     Then container log should contain bootstrap.servers = [localhost:11111]
-     And container log should contain Connection to node -1 (localhost/127.0.0.1:11111) could not be established.
+    And container log should contain started in
+    And container log should contain Connection to node -1 (localhost/127.0.0.1:11111) could not be established.
+

--- a/tests/features/kogito-management-console.feature
+++ b/tests/features/kogito-management-console.feature
@@ -1,5 +1,4 @@
 @quay.io/kiegroup/kogito-management-console
-
 Feature: kogito-management-console feature
 
   Scenario: verify if all labels are correctly set.
@@ -21,13 +20,17 @@ Feature: kogito-management-console feature
       | variable     | value |
       | SCRIPT_DEBUG | true  |
     Then container log should contain + exec java -XshowSettings:properties -Dkogito.dataindex.http.url=http://localhost:8180 -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-management-console-runner.jar
-     And container log should contain Data index url not set, default will be used: http://localhost:8180
+    And container log should contain Data index url not set, default will be used: http://localhost:8180
+    And container log should contain started in
+    And container log should not contain Application failed to start
 
   Scenario: Verify if the debug is correctly enabled and set data-index url
     When container is started with env
-      | variable                     | value             |
-      | SCRIPT_DEBUG                 | true              |
-      | KOGITO_DATAINDEX_HTTP_URL    | http://test:9090  |
+      | variable                  | value            |
+      | SCRIPT_DEBUG              | true             |
+      | KOGITO_DATAINDEX_HTTP_URL | http://test:9090 |
     Then container log should contain + exec java -XshowSettings:properties -Dkogito.dataindex.http.url=http://test:9090 -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-management-console-runner.jar
-     And container log should not contain Data index url not set, default will be used: http://localhost:8180
+    And container log should not contain Data index url not set, default will be used: http://localhost:8180
+    And container log should contain started in
+    And container log should not contain Application failed to start
 

--- a/tests/features/kogito-quarkus-jvm-ubi8.feature
+++ b/tests/features/kogito-quarkus-jvm-ubi8.feature
@@ -1,5 +1,4 @@
 @quay.io/kiegroup/kogito-quarkus-jvm-ubi8
-
 Feature: Kogito-quarkus-ubi8 feature.
 
   Scenario: verify if all labels are correctly set.

--- a/tests/features/kogito-quarkus-ubi8-s2i.feature
+++ b/tests/features/kogito-quarkus-ubi8-s2i.feature
@@ -1,56 +1,109 @@
 @quay.io/kiegroup/kogito-quarkus-ubi8-s2i
 Feature: kogito-quarkus-ubi8-s2i image tests
 
-  Scenario: Verify if the s2i build is finished as expected and if it is listening on the expected port
-    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
-      | variable       | value                     |
-      | LIMIT_MEMORY   | 3221225472                |
+  Scenario: Verify if the s2i build is finished as expected using native build and runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable     | value      |
+      | NATIVE       | true       |
+      | LIMIT_MEMORY | 3221225472 |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     | 
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
     And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
     And file /home/kogito/ssl-libs/libsunec.so should exist
     And file /home/kogito/cacerts should exist
     And s2i build log should contain -J-Xmx2576980377
 
-  Scenario: Verify if the s2i build is finished as expected performing a non native build
-    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-      | variable            | value                     |
-      | NATIVE              | false                     |
-      | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
+  Scenario: Verify if the s2i build is finished as expected using native build and no runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master
+      | variable     | value      |
+      | NATIVE       | true       |
+      | LIMIT_MEMORY | 3221225472 |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     | 
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
+    And file /home/kogito/ssl-libs/libsunec.so should exist
+    And file /home/kogito/cacerts should exist
+    And s2i build log should contain -J-Xmx2576980377
+
+  Scenario: Verify if the s2i build is finished as expected with non native build and no runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master
+      | variable | value |
+      | NATIVE   | false |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+    And file /home/kogito/ssl-libs/libsunec.so should exist
+    And file /home/kogito/cacerts should exist
+
+  Scenario: Verify if the s2i build is finished as expected performing a non native build with runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
+      | variable     | value                     |
+      | NATIVE       | false                     |
+      | JAVA_OPTIONS | -Dquarkus.log.level=DEBUG |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
     And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
     And container log should contain DEBUG [io.qua.
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Dquarkus.log.level=DEBUG
 
-  Scenario: Verify if the s2i build is finished as expected performing a non native build and if it is listening on the expected port
+  Scenario: Verify if the s2i build is finished as expected performing a non native build and if it is listening on the expected port , test uses custom properties file to test the port configuration.
     Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
       | variable | value |
       | NATIVE   | false |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     | 
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
     And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+
+  Scenario: Verify if the s2i build is finished as expected performing a native build and if it is listening on the expected port, test uses custom properties file to test the port configuration.
+    Given s2i build /tmp/kogito-examples from rules-quarkus-helloworld using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable     | value      |
+      | NATIVE       | true       |
+      | LIMIT_MEMORY | 6442450944 |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
 
   Scenario: Verify if the s2i build is finished as expected performing a non native build with persistence enabled
     Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
@@ -64,48 +117,107 @@ Feature: kogito-quarkus-ubi8-s2i image tests
     And run sh -c 'cat /home/kogito/data/protobufs/persons-md5.txt' in container and immediately check its output for b19f6d73a0a1fea0bfbd8e2e30701d78
     And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
 
+  # ignore until https://issues.redhat.com/browse/KOGITO-2003 is not fixed.
+  @ignore
   Scenario: Verify if the s2i build is finished as expected performing a native build with persistence enabled
     Given s2i build https://github.com/kiegroup/kogito-examples.git from process-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
       | variable          | value         |
       | NATIVE            | true          |
+      | LIMIT_MEMORY      | 6442450944    |
       | MAVEN_ARGS_APPEND | -Ppersistence |
-    Then file /home/kogito/bin/process-quarkus-example-runner should exist
+    Then run sh -c 'cat /home/kogito/data/protobufs/persons-md5.txt' in container and immediately check its output for b19f6d73a0a1fea0bfbd8e2e30701d78
+    And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
+    And file /home/kogito/bin/process-quarkus-example-runner should exist
     And s2i build log should contain '/home/kogito/bin/demo.orders.proto' -> '/home/kogito/data/protobufs/demo.orders.proto'
     And s2i build log should contain '/home/kogito/bin/persons.proto' -> '/home/kogito/data/protobufs/persons.proto'
     And s2i build log should contain ---> [persistence] generating md5 for persistence files
-    And run sh -c 'cat /home/kogito/data/protobufs/persons-md5.txt' in container and immediately check its output for b19f6d73a0a1fea0bfbd8e2e30701d78
-    And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
 
-  Scenario: Verify if the multi-module s2i build is finished as expected performing a non native build and if it is listening on the expected port
+  Scenario: Scenario: Verify if the multi-module s2i build is finished as expected performing a non native build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from . using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-      | variable          | value                           |
-      | NATIVE            | false                           |
-      | ARTIFACT_DIR      | rules-quarkus-helloworld/target   |
-      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am  |
+      | variable          | value                            |
+      | NATIVE            | false                            |
+      | ARTIFACT_DIR      | rules-quarkus-helloworld/target  |
+      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am |
     Then check that page is served
-      | property        | value                    |
-      | port            | 8080                     |
-      | path            | /hello                   |
-      | request_method  | POST                     | 
-      | content_type    | application/json         |
-      | request_body    | {"strings":["hello"]}    |
-      | wait            | 80                       |
-      | expected_phrase | ["hello","world"]        |
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
     And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+
+  Scenario: Verify if the multi-module s2i build is finished as expected performing a native build
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from . using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable          | value                            |
+      | NATIVE            | true                             |
+      | LIMIT_MEMORY      | 6442450944                       |
+      | ARTIFACT_DIR      | rules-quarkus-helloworld/target  |
+      | MAVEN_ARGS_APPEND | -pl rules-quarkus-helloworld -am |
+    Then check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
 
   Scenario: Perform a incremental s2i build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using master
-      | variable          | value                  |
-      | NATIVE            | false                  |
+      | variable | value |
+      | NATIVE   | false |
     Then s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+    And check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
 
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using master
-      | variable          | value    |
-      | NATIVE            | false    |
+      | variable | value |
+      | NATIVE   | false |
     Then s2i build log should contain Expanding artifacts from incremental build...
     And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner.jar should exist
+    And check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
+
+  Scenario: Perform a third incremental s2i build, this time, with native enabled
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from rules-quarkus-helloworld with env and incremental using master
+      | variable     | value      |
+      | NATIVE       | true       |
+      | LIMIT_MEMORY | 6442450944 |
+    Then s2i build log should contain Expanding artifacts from incremental build...
+    And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist
+    And check that page is served
+      | property        | value                 |
+      | port            | 8080                  |
+      | path            | /hello                |
+      | request_method  | POST                  |
+      | content_type    | application/json      |
+      | request_body    | {"strings":["hello"]} |
+      | wait            | 80                    |
+      | expected_phrase | ["hello","world"]     |
 
   Scenario: verify if all labels are correctly set.
     Given image is built
@@ -132,10 +244,27 @@ Feature: kogito-quarkus-ubi8-s2i image tests
 
   Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly
     Given s2i build /tmp/kogito-examples from dmn-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-jvm-ubi8:latest
-      | variable          | value                           |
-      | NATIVE            | false                           |
-      | KOGITO_VERSION    | 8.0.0-SNAPSHOT                  |
+      | variable       | value          |
+      | NATIVE         | false          |
+      | KOGITO_VERSION | 8.0.0-SNAPSHOT |
     Then file /home/kogito/bin/project-1.0-SNAPSHOT-runner.jar should exist
+    And check that page is served
+      | property        | value                                                                                            |
+      | port            | 8080                                                                                             |
+      | path            | /Traffic%20Violation                                                                             |
+      | wait            | 80                                                                                               |
+      | expected_phrase | Should the driver be suspended?                                                                  |
+      | request_method  | POST                                                                                             |
+      | content_type    | application/json                                                                                 |
+      | request_body    | {"Driver": {"Points": 2}, "Violation": {"Type": "speed","Actual Speed": 120,"Speed Limit": 100}} |
+
+  Scenario: Verify that the Kogito Maven archetype is generating the project and compiling it correctly using native build
+    Given s2i build /tmp/kogito-examples from dmn-quarkus-example using master and runtime-image quay.io/kiegroup/kogito-quarkus-ubi8:latest
+      | variable       | value          |
+      | NATIVE         | true           |
+      | LIMIT_MEMORY   | 6442450944     |
+      | KOGITO_VERSION | 8.0.0-SNAPSHOT |
+    Then file /home/kogito/bin/project-1.0-SNAPSHOT-runner should exist
     And check that page is served
       | property        | value                                                                                            |
       | port            | 8080                                                                                             |

--- a/tests/features/kogito-quarkus-ubi8.feature
+++ b/tests/features/kogito-quarkus-ubi8.feature
@@ -1,5 +1,4 @@
 @quay.io/kiegroup/kogito-quarkus-ubi8
-
 Feature: Kogito-quarkus-ubi8 feature.
 
   Scenario: verify if all labels are correctly set.
@@ -17,3 +16,19 @@ Feature: Kogito-quarkus-ubi8 feature.
     When container is started with command bash
     Then  file /home/kogito/ssl-libs/libsunec.so should exist
     And file /home/kogito/cacerts should exist
+
+  Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
+    Given s2i build /tmp/kogito-examples/rules-quarkus-helloworld-native/ from target
+      | variable            | value                     |
+      | NATIVE              | false                     |
+      | JAVA_OPTIONS        | -Dquarkus.log.level=DEBUG |
+    Then check that page is served
+      | property        | value                    |
+      | port            | 8080                     |
+      | path            | /hello                   |
+      | request_method  | POST                     |
+      | content_type    | application/json         |
+      | request_body    | {"strings":["hello"]}    |
+      | wait            | 80                       |
+      | expected_phrase | ["hello","world"]        |
+    And file /home/kogito/bin/rules-quarkus-helloworld-runner should exist

--- a/tests/features/kogito-springboot-ubi8-s2i.feature
+++ b/tests/features/kogito-springboot-ubi8-s2i.feature
@@ -1,9 +1,22 @@
 @quay.io/kiegroup/kogito-springboot-ubi8-s2i
-
 Feature: kogito-springboot-ubi8-s2i image tests
 
   Scenario: Verify if the s2i build is finished as expected
     Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+      | variable     | value        |
+      | JAVA_OPTIONS | -Ddebug=true |
+    Then check that page is served
+      | property             | value     |
+      | port                 | 8080      |
+      | path                 | /orders/1 |
+      | wait                 | 80        |
+      | expected_status_code | 204       |
+    And file /home/kogito/bin/process-springboot-example.jar should exist
+    And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
+    And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
+
+  Scenario: Verify if the s2i build is finished as expected with no runtime image
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using master
       | variable            | value        |
       | JAVA_OPTIONS        | -Ddebug=true |
     Then check that page is served
@@ -16,12 +29,35 @@ Feature: kogito-springboot-ubi8-s2i image tests
     And container log should contain DEBUG 1 --- [           main] o.s.boot.SpringApplication
     And run sh -c 'echo $JAVA_OPTIONS' in container and immediately check its output for -Ddebug=true
 
+  Scenario: Verify if the s2i build is finished as expected and if it is listening on the expected port, test uses custom properties file to test the port configuration.
+    Given s2i build /tmp/kogito-examples from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+      | variable            | value        |
+    Then check that page is served
+      | property             | value     |
+      | port                 | 8080      |
+      | path                 | /orders/1 |
+      | wait                 | 80        |
+      | expected_status_code | 204       |
+    And file /home/kogito/bin/process-springboot-example.jar should exist
+    And container log should contain Tomcat initialized with port(s): 8080 (http)
+
+  Scenario: Verify if the s2i build is finished as expected with persistence enabled
+    Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+      | variable          | value         |
+      | MAVEN_ARGS_APPEND | -Ppersistence |
+    Then file /home/kogito/bin/process-springboot-example.jar should exist
+    And s2i build log should contain '/home/kogito/bin/demo.orders.proto' -> '/home/kogito/data/protobufs/demo.orders.proto'
+    And s2i build log should contain '/home/kogito/bin/persons.proto' -> '/home/kogito/data/protobufs/persons.proto'
+    And s2i build log should contain ---> [persistence] generating md5 for persistence files
+    And run sh -c 'cat /home/kogito/data/protobufs/persons-md5.txt' in container and immediately check its output for b19f6d73a0a1fea0bfbd8e2e30701d78
+    And run sh -c 'cat /home/kogito/data/protobufs/demo.orders-md5.txt' in container and immediately check its output for 02b40df868ebda3acb3b318b6ebcc055
+
   Scenario: Verify if the s2i build is finished as expected using multi-module build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from . using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
-      | variable            | value                           |
-      | JAVA_OPTIONS        | -Ddebug=true                    |
-      | ARTIFACT_DIR        | process-springboot-example/target   |
-      | MAVEN_ARGS_APPEND   | -pl process-springboot-example -am  |
+      | variable          | value                              |
+      | JAVA_OPTIONS      | -Ddebug=true                       |
+      | ARTIFACT_DIR      | process-springboot-example/target  |
+      | MAVEN_ARGS_APPEND | -pl process-springboot-example -am |
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |

--- a/tests/features/kogito-springboot-ubi8.feature
+++ b/tests/features/kogito-springboot-ubi8.feature
@@ -1,5 +1,4 @@
 @quay.io/kiegroup/kogito-springboot-ubi8
-
 Feature: springboot-quarkus-ubi8 feature.
 
   Scenario: verify if all labels are correctly set.
@@ -18,7 +17,6 @@ Feature: springboot-quarkus-ubi8 feature.
     Then run sh -c 'echo $JAVA_HOME' in container and immediately check its output for /usr/lib/jvm/java-11
     And run sh -c 'echo $JAVA_VENDOR' in container and immediately check its output for openjdk
     And run sh -c 'echo $JAVA_VERSION' in container and immediately check its output for 11
-
 
   Scenario: Verify if the binary build is finished as expected and if it is listening on the expected port
     Given s2i build /tmp/kogito-examples/process-springboot-example from target

--- a/tests/test-apps/clone-repo.sh
+++ b/tests/test-apps/clone-repo.sh
@@ -2,6 +2,9 @@
 #
 # Clone the kogito-examples and edit the rules-quarkus-helloworld and dmn-quarkus-example for testing purposes
 
+# exit when any command fails
+set -e
+
 TEST_DIR=`pwd`
 cd /tmp
 rm -rf kogito-examples/
@@ -10,20 +13,24 @@ cd kogito-examples/
 git fetch origin --tags
 git checkout master
 
+# make a new copy of rules-quarkus-helloworld for native tests
+cp -rv  /tmp/kogito-examples/rules-quarkus-helloworld/ /tmp/kogito-examples/rules-quarkus-helloworld-native/
+
 # generating the app binaries to test the binary build
 mvn -f rules-quarkus-helloworld clean package -DskipTests
 mvn -f process-springboot-example clean package -DskipTests
+mvn -f rules-quarkus-helloworld-native -Pnative clean package -DskipTests
 
 # preparing directory to run kogito maven archetypes tests
 cp /tmp/kogito-examples/dmn-quarkus-example/src/main/resources/* /tmp/kogito-examples/dmn-quarkus-example/
 rm -rf /tmp/kogito-examples/dmn-quarkus-example/src
 rm -rf /tmp/kogito-examples/dmn-quarkus-example/pom.xml
 
-# by adding the application.properties file telling quarkus to start on
+# by adding the application.properties file telling app to start on
 # port 10000, the purpose of this tests is make sure that the images
 # will ensure the use of the port 8080.
 cp ${TEST_DIR}/application.properties /tmp/kogito-examples/rules-quarkus-helloworld/src/main/resources/META-INF/
+(echo ""; echo "server.port=10000") >> /tmp/kogito-examples/process-springboot-example/src/main/resources/application.properties
 
-cd rules-quarkus-helloworld
 git add --all  :/
 git commit -am "test"


### PR DESCRIPTION
This commit addresses:
- limit the memory for all native builds
- applies the same behave tests changes of https://github.com/kiegroup/kogito-images/pull/141 added to satisfy tests for sanity checks
- improves the manage-version script to match the change on kogito-examples, artifacts does n ot have version anymore :)
- update make file to:
	- run the tests after every image build with make command.
	- little fix for images tag when releasing, make push
- Fix the behavior for the INFINISPAN_USEAUTH
        - If env not set or empty, this should default to false.

Signed-off-by: spolti <fspolti@redhat.com>
