### PR TITLE
[KOGITO-2370] Update artifacts should update kogito version

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -99,10 +99,32 @@ def update_kogito_modules(target_version):
                 print(
                     "Updating module {0} version from {1} to {2}".format(data['name'], data['version'], target_version))
                 data['version'] = target_version
+
+            with open(os.path.join(modules_dir, module), 'w') as m:
+                yaml_loader().dump(data, m)
+
+    except TypeError:
+        raise
+
+    update_kogito_version_in_modules(target_version)
+
+def update_kogito_version_in_modules(target_version):
+    """
+    Update every module.yaml file listed on MODULES as well the envs listed on ENVS.
+    :param target_version:  version used to update all needed module.yaml files
+    """
+    modules_dir = "modules"
+    try:
+
+        for module in MODULES:
+            module = module + "/module.yaml"
+            with open(os.path.join(modules_dir, module)) as m:
+                data = yaml_loader().load(m)
                 if 'envs' in data:
                     for index, env in enumerate(data['envs'], start=0):
                         for target_env in ENVS:
                             if target_env == env['name']:
+                                print("Updating module {0} env var {1} with value {2}".format(data['name'], target_env, target_version))
                                 data['envs'][index]['value'] = target_version
 
             with open(os.path.join(modules_dir, module), 'w') as m:

--- a/scripts/update-artifacts.py
+++ b/scripts/update-artifacts.py
@@ -7,6 +7,8 @@
 # ruamel.yaml
 # elementpath 
 
+import sys
+sys.dont_write_bytecode = True
 
 import xml.etree.ElementTree as ET
 import requests
@@ -14,6 +16,8 @@ import subprocess as sp
 import os
 import argparse
 from ruamel.yaml import YAML
+
+import common
 
 DEFAULT_REPO_URL = "https://repository.jboss.org/"
 DEFAULT_VERSION = "8.0.0-SNAPSHOT"
@@ -125,3 +129,5 @@ if __name__ == "__main__":
         
         update_artifacts(service, moduleYamlFile)
         print("Successfully updated the artifacts for: ", serviceName)
+    
+    common.update_kogito_version_in_modules(args.version)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2370

When updating artifacts in modules, we should also update the default KOGITO_VERSION env var in modules

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster