### PR TITLE
[KOGITO-2445] maven repo added to tests only

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -24,6 +24,8 @@ pipeline {
         string(name: 'IMAGE_TAG', defaultValue: '', description: 'Image tag to use to deploy images')
 
         string(name: 'MAVEN_ARTIFACT_REPOSITORY', defaultValue: '', description: 'Maven repository where the build artifacts are present')
+
+        booleanParam(name: 'SKIP_TESTS', defaultValue: false, description: 'Skip tests')
     }
 
     // Keep commented if no env var is defined
@@ -64,9 +66,10 @@ pipeline {
                     }
 
                     // Set the mirror url only if no artifact repository is given
-                    if (params.MAVEN_ARTIFACT_REPOSITORY != '' 
+                    if (params.MAVEN_ARTIFACT_REPOSITORY == '' 
                             && env.MAVEN_MIRROR_REPOSITORY != null
                             && env.MAVEN_MIRROR_REPOSITORY != ''){
+                        echo "Set Maven mirror url"
                         env.MAVEN_MIRROR_URL = env.MAVEN_MIRROR_REPOSITORY
                     }
                 }
@@ -87,7 +90,8 @@ pipeline {
                     sh "cat modules/kogito-jobs-service/module.yaml"
                     sh "cat modules/kogito-management-console/module.yaml"
                     sh "cat tests/test-apps/clone-repo.sh"
-                    sh "cat ${HOME}/.m2/settings.xml"
+                    sh "cat tests/features/kogito-quarkus-ubi8-s2i.feature"
+                    sh "cat tests/features/kogito-springboot-ubi8-s2i.feature"
                 }
             }
         }
@@ -113,6 +117,11 @@ pipeline {
             }
         }
         stage('Prepare offline kogito-examples') {
+            when {
+                expression {
+                    return !params.SKIP_TESTS;
+                }
+            }
             steps {
                 sh "make clone-repos"
             }
@@ -126,10 +135,10 @@ pipeline {
                             copyWorkspace("$image")
                             dir(getWorkspacePath("$image")){
                                 try{
-                                    sh "make ${image}"
+                                    sh "make ${image} ignore_test=${params.SKIP_TESTS}"
                                 }
                                 finally{
-                                    junit 'target/test/results/*.xml'
+                                    junit testResults: 'target/test/results/*.xml', allowEmptyResults: true
                                 }
                             
                             }

--- a/tests/features/kogito-springboot-ubi8-s2i.feature
+++ b/tests/features/kogito-springboot-ubi8-s2i.feature
@@ -31,6 +31,8 @@ Feature: kogito-springboot-ubi8-s2i image tests
 
   Scenario: Verify if the s2i build is finished as expected and if it is listening on the expected port, test uses custom properties file to test the port configuration.
     Given s2i build /tmp/kogito-examples from process-springboot-example using master and runtime-image quay.io/kiegroup/kogito-springboot-ubi8:latest
+      # Leave those here as placeholder for scripts adding variable to the test. No impact on tests if empty.
+      | variable | value |
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |
@@ -69,6 +71,8 @@ Feature: kogito-springboot-ubi8-s2i image tests
 
   Scenario: Scenario: Perform a incremental s2i build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using master
+      # Leave those here as placeholder for scripts adding variable to the test. No impact on tests if empty.
+      | variable | value |
     Then check that page is served
       | property             | value     |
       | port                 | 8080      |
@@ -80,6 +84,8 @@ Feature: kogito-springboot-ubi8-s2i image tests
   # Since the same image is used we can do a subsequent incremental build and verify if it is working as expected.
   Scenario: Perform a second incremental s2i build
     Given s2i build https://github.com/kiegroup/kogito-examples.git from process-springboot-example with env and incremental using master
+      # Leave those here as placeholder for scripts adding variable to the test. No impact on tests if empty.
+      | variable | value |
     Then s2i build log should contain Expanding artifacts from incremental build...
     And s2i build log should not contain WARNING: Clean build will be performed because of error saving previous build artifacts
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2445

The feature tests are updated with the given artifactory as it is the one we want to test against.
The env var is no more set directly into the module directly else it will be packaged with the image as default repository when building ...

and added option to skip tests in deploy

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster