### PR TITLE
KOGITO-2812 - add explainability image

### DIFF
--- a/.github/workflows/run-bats-tests.yml
+++ b/.github/workflows/run-bats-tests.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           $HOME/bin/bats modules/kogito-data-index/tests/bats
 
+      - name: run kogito-explainability tests
+        working-directory: ${{ github.workspace }}
+        run: |
+          $HOME/bin/bats modules/kogito-explainability/tests/bats
+
       - name: run kogito-graalvm-scripts tests
         working-directory: ${{ github.workspace }}
         run: |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ IMAGES = ["kogito-quarkus-ubi8",
             "kogito-springboot-ubi8",
             "kogito-springboot-ubi8-s2i",
             "kogito-data-index",
+            "kogito-explainability",
             "kogito-jobs-service",
             "kogito-management-console"]
 
@@ -48,6 +49,7 @@ pipeline{
                 sh """
                     ./cekit-image-validator-runner image.yaml
                     ./cekit-image-validator-runner kogito-data-index-overrides.yaml
+                    ./cekit-image-validator-runner kogito-explainability-overrides.yaml
                     ./cekit-image-validator-runner kogito-jobs-service-overrides.yaml
                     ./cekit-image-validator-runner kogito-management-console-overrides.yaml
                     ./cekit-image-validator-runner kogito-quarkus-jvm-overrides.yaml

--- a/Jenkinsfile-Nightly
+++ b/Jenkinsfile-Nightly
@@ -8,6 +8,7 @@ IMAGES = ["kogito-quarkus-ubi8",
             "kogito-springboot-ubi8",
             "kogito-springboot-ubi8-s2i",
             "kogito-data-index",
+            "kogito-explainability",
             "kogito-jobs-service",
             "kogito-management-console"]
 
@@ -46,6 +47,7 @@ pipeline{
                 sh """
                     ./cekit-image-validator-runner image.yaml
                     ./cekit-image-validator-runner kogito-data-index-overrides.yaml
+                    ./cekit-image-validator-runner kogito-explainability-overrides.yaml
                     ./cekit-image-validator-runner kogito-jobs-service-overrides.yaml
                     ./cekit-image-validator-runner kogito-management-console-overrides.yaml
                     ./cekit-image-validator-runner kogito-quarkus-jvm-overrides.yaml
@@ -97,6 +99,7 @@ pipeline{
                 docker tag quay.io/kiegroup/kogito-springboot-ubi8:latest                 quay.io/kiegroup/kogito-springboot-ubi8-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                 docker tag quay.io/kiegroup/kogito-springboot-ubi8-s2i:latest             quay.io/kiegroup/kogito-springboot-ubi8-s2i-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                 docker tag quay.io/kiegroup/kogito-data-index:latest                      quay.io/kiegroup/kogito-data-index-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
+                docker tag quay.io/kiegroup/kogito-explainability:latest                  quay.io/kiegroup/kogito-explainability-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                 docker tag quay.io/kiegroup/kogito-jobs-service:latest                    quay.io/kiegroup/kogito-jobs-service-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                 docker tag quay.io/kiegroup/kogito-management-console:latest              quay.io/kiegroup/kogito-management-console-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
 	        """
@@ -112,6 +115,7 @@ pipeline{
                         docker push quay.io/kiegroup/kogito-springboot-ubi8-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                         docker push quay.io/kiegroup/kogito-springboot-ubi8-s2i-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                         docker push quay.io/kiegroup/kogito-data-index-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
+                        docker push quay.io/kiegroup/kogito-explainability-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                         docker push quay.io/kiegroup/kogito-jobs-service-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                         docker push quay.io/kiegroup/kogito-management-console-nightly:\$(echo \${GIT_COMMIT} | cut -c1-7)
                        """

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -9,6 +9,7 @@ IMAGES = [
             "kogito-springboot-ubi8",
             "kogito-springboot-ubi8-s2i",
             "kogito-data-index",
+            "kogito-explainability",
             "kogito-jobs-service",
             "kogito-management-console"
          ]
@@ -84,6 +85,7 @@ pipeline {
 
                     // Debug purpose in case of issue
                     sh "cat modules/kogito-data-index/module.yaml"
+                    sh "cat modules/kogito-explainability/module.yaml"
                     sh "cat modules/kogito-jobs-service/module.yaml"
                     sh "cat modules/kogito-management-console/module.yaml"
                 }
@@ -118,6 +120,7 @@ pipeline {
                 sh """
                     ./cekit-image-validator-runner image.yaml
                     ./cekit-image-validator-runner kogito-data-index-overrides.yaml
+                    ./cekit-image-validator-runner kogito-explainability-overrides.yaml
                     ./cekit-image-validator-runner kogito-jobs-service-overrides.yaml
                     ./cekit-image-validator-runner kogito-management-console-overrides.yaml
                     ./cekit-image-validator-runner kogito-quarkus-jvm-overrides.yaml

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -6,6 +6,7 @@ IMAGES = ["kogito-quarkus-ubi8",
                     "kogito-springboot-ubi8",
                     "kogito-springboot-ubi8-s2i",
                     "kogito-data-index",
+                    "kogito-explainability",
                     "kogito-jobs-service",
                     "kogito-management-console"]
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CEKIT_CMD := cekit -v ${cekit_option}
 # Build all images
 .PHONY: build
 # start to build the images
-build: clone-repos kogito-quarkus-ubi8 kogito-quarkus-jvm-ubi8 kogito-quarkus-ubi8-s2i kogito-springboot-ubi8 kogito-springboot-ubi8-s2i kogito-data-index kogito-jobs-service kogito-management-console
+build: clone-repos kogito-quarkus-ubi8 kogito-quarkus-jvm-ubi8 kogito-quarkus-ubi8-s2i kogito-springboot-ubi8 kogito-springboot-ubi8-s2i kogito-data-index kogito-explainability kogito-jobs-service kogito-management-console
 
 clone-repos:
 # if the NO_TEST env defined, proceed with the tests, as first step prepare the repo to be used
@@ -93,6 +93,19 @@ ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-data-index:${IMAGE_VERSION} quay.io/kiegroup/kogito-data-index:${SHORTENED_LATEST_VERSION}
 endif
 
+# build the quay.io/kiegroup/kogito-explainability image
+kogito-explainability:
+ifneq ($(ignore_build),true)
+	${CEKIT_CMD} build --overrides-file kogito-explainability-overrides.yaml ${BUILD_ENGINE}
+endif
+# if ignore_test is set tu true, ignore the tests
+ifneq ($(ignore_test),true)
+	${CEKIT_CMD} test --overrides-file kogito-explainability-overrides.yaml behave
+endif
+ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
+	${BUILD_ENGINE} tag quay.io/kiegroup/kogito-explainability:${IMAGE_VERSION} quay.io/kiegroup/kogito-explainability:${SHORTENED_LATEST_VERSION}
+endif
+
 # build the quay.io/kiegroup/kogito-jobs-service image
 kogito-jobs-service:
 ifneq ($(ignore_build),true)
@@ -136,6 +149,8 @@ _push:
 	docker push quay.io/kiegroup/kogito-springboot-ubi8-s2i:latest
 	docker push quay.io/kiegroup/kogito-data-index:${IMAGE_VERSION}
 	docker push quay.io/kiegroup/kogito-data-index:latest
+	docker push quay.io/kiegroup/kogito-explainability:${IMAGE_VERSION}
+	docker push quay.io/kiegroup/kogito-explainability:latest
 	docker push quay.io/kiegroup/kogito-jobs-service:${IMAGE_VERSION}
 	docker push quay.io/kiegroup/kogito-jobs-service:latest
 	docker push quay.io/kiegroup/kogito-management-console:${IMAGE_VERSION}
@@ -148,6 +163,7 @@ ifneq ($(findstring rc,$(IMAGE_VERSION)), rc)
 	docker push quay.io/kiegroup/kogito-springboot-ubi8:${SHORTENED_LATEST_VERSION}
 	docker push quay.io/kiegroup/kogito-springboot-ubi8-s2i:${SHORTENED_LATEST_VERSION}
 	docker push quay.io/kiegroup/kogito-data-index:${SHORTENED_LATEST_VERSION}
+	docker push quay.io/kiegroup/kogito-explainability:${SHORTENED_LATEST_VERSION}
 	docker push quay.io/kiegroup/kogito-jobs-service:${SHORTENED_LATEST_VERSION}
 	docker push quay.io/kiegroup/kogito-management-console:${SHORTENED_LATEST_VERSION}
 endif

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Table of Contents
         - [Kogito Spring Boot Runtime Image example](#kogito-spring-boot-runtime-image-example)
   - [Kogito Component Images](#kogito-component-images)
     - [Kogito Data Index Component Image](#kogito-data-index-component-image)
+    - [Kogito Explainability Component Image](#kogito-explainability-component-image)
     - [Kogito Jobs Service Component Image](#kogito-jobs-service-component-image)
     - [Kogito Management Console Component Image](#kogito-management-console-component-image)
   - [Using Kogito Images to Deploy Apps on OpenShift](#using-kogito-images-to-deploy-apps-on-openshift)
@@ -565,6 +566,7 @@ by providing extra capabilities, like managing the processes on a web UI or prov
 Today we have 3 Kogito Component Images:
 
 * [quay.io/kiegroup/kogito-data-index](https://quay.io/kiegroup/kogito-data-index)
+* [quay.io/kiegroup/kogito-explainability](https://quay.io/kiegroup/kogito-explainability)
 * [quay.io/kiegroup/kogito-jobs-service](htps://quay.io/kiegroup/kogito-jobs-service)
 * [quay.io/kiegroup/kogito-management-console](https://quay.io/kiegroup/kogito-management-console)
 
@@ -593,6 +595,26 @@ To know what configurations this image accepts please take a look [here](kogito-
 The [Kogito Operator](https://github.com/kiegroup/kogito-cloud-operator) can be used to deploy the Kogito Data Index Service 
 to your Kogito infrastructure on a Kubernetes cluster and provide its capabilities to your Kogito applications.
 
+### Kogito Explainability Component Image
+
+The Explainability Service aims to provide explainability on the decisions that have been taken by kogito runtime applications. 
+
+Basic usage
+```bash
+$ docker run -it quay.io/kiegroup/kogito-explainability:latest
+```
+
+To enable debug just use this env while running this image:
+
+```bash
+docker run -it --env SCRIPT_DEBUG=true quay.io/kiegroup/kogito-explainability:latest
+```
+You should notice a few debug messages being printed in the system output.
+
+To know what configurations this image accepts please take a look [here](kogito-explainability-overrides.yaml) on the **envs** section.
+
+The [Kogito Operator](https://github.com/kiegroup/kogito-cloud-operator) can be used to deploy the Kogito Explainability Service 
+to your Kogito infrastructure on a Kubernetes cluster and provide its capabilities to your Kogito applications.
 
 ### Kogito Jobs Service Component Image
 
@@ -869,6 +891,7 @@ With this Makefile you can:
      $ make kogito-springboot-ubi8 
      $ make kogito-springboot-ubi8-s2i
      $ make kogito-data-index
+     $ make kogito-explainability
      $ make kogito-jobs-service 
      $ make kogito-management-console
      ```
@@ -917,6 +940,7 @@ To better understand the CeKit Modules, please visit this [link](https://docs.ce
 Below you can find all modules used to build the Kogito Images
 
 - [kogito-data-index](modules/kogito-data-index): Installs and Configure the data-index jar inside the image.
+- [kogito-explainability](modules/kogito-explainability): Installs and Configure the explainability jar inside the image.
 - [kogito-epel](modules/kogito-epel): Configures the epel repository on the target image.
 - [kogito-graalvm-installer](modules/kogito-graalvm-installer): Installs the GraalVM on the target Image.
 - [kogito-graalvm-scripts](modules/kogito-graalvm-scripts): Configures the GraalVM on the target image and provides custom configuration script. 
@@ -943,6 +967,7 @@ For each image, we use a specific *-overrides.yaml file which will specific the 
 Please inspect the images overrides files to learn which modules are being installed:
 
 - [quay.io/kiegroup/kogito-data-index](kogito-data-index-overrides.yaml)
+- [quay.io/kiegroup/kogito-explainability](kogito-explainability-overrides.yaml)
 - [quay.io/kiegroup/kogito-jobs-service](kogito-jobs-service-overrides.yaml)
 - [quay.io/kiegroup/kogito-management-console](kogito-management-console-overrides.yaml)
 - [quay.io/kiegroup/kogito-quarkus-jvm-ubi8](kogito-quarkus-jvm-overrides.yaml)

--- a/kogito-explainability-overrides.yaml
+++ b/kogito-explainability-overrides.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+
+name: "quay.io/kiegroup/kogito-explainability"
+description: "Runtime image for Kogito Explainability Service"
+
+labels:
+- name: "io.k8s.description"
+  value: "Runtime image for Kogito Explainability Service"
+- name: "io.k8s.display-name"
+  value: "Kogito Explainability Service"
+- name: "io.openshift.tags"
+  value: "kogito,explainability"
+- name: "io.openshift.expose-services"
+  value: "8080:http"
+
+envs:
+  - name: "SCRIPT_DEBUG"
+    example: "true"
+    description: "If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed. Also debug JVM initialization."
+  - name: "HTTP_PORT"
+    example: "9090"
+    description: "Defines which port the Explainability Container Image will listen on."
+
+ports:
+- value: 8080
+
+modules:
+  install:
+  - name: org.kie.kogito.image.dependencies
+  - name: org.kie.kogito.system.user
+  - name: org.kie.kogito.logging
+  - name: org.kie.kogito.openjdk
+    version: "11-headless"
+  - name: org.kie.kogito.launch.scripts
+  - name: org.kie.kogito.explainability
+
+run:
+  workdir: "/home/kogito"
+  user: 1001
+  cmd:
+    - "/home/kogito/kogito-app-launch.sh"
+

--- a/modules/kogito-explainability/added/kogito-app-launch.sh
+++ b/modules/kogito-explainability/added/kogito-app-launch.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+#import
+source ${KOGITO_HOME}/launch/logging.sh
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    SHOW_JVM_SETTINGS="-XshowSettings:properties"
+    log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+    log_info "JVM settings debug is enabled."
+fi
+
+
+# Configuration scripts
+# Any configuration script that needs to run on image startup must be added here.
+CONFIGURE_SCRIPTS=(
+  ${KOGITO_HOME}/launch/kogito-explainability.sh
+)
+source ${KOGITO_HOME}/launch/configure.sh
+#############################################
+
+exec java ${SHOW_JVM_SETTINGS} ${JAVA_OPTIONS} ${KOGITO_EXPLAINABILITY_PROPS} \
+        -Djava.library.path=$KOGITO_HOME/lib \
+        -Dquarkus.http.host=0.0.0.0 \
+        -jar $KOGITO_HOME/bin/kogito-explainability-runner.jar

--- a/modules/kogito-explainability/added/launch/kogito-explainability.sh
+++ b/modules/kogito-explainability/added/launch/kogito-explainability.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+
+function prepareEnv() {
+    # keep it on alphabetical order
+    unset HTTP_PORT
+}
+
+function configure() {
+    configure_explainability_http_port
+}
+
+function configure_explainability_http_port {
+    local httpPort=${HTTP_PORT:-8080}
+    KOGITO_EXPLAINABILITY_PROPS="${KOGITO_EXPLAINABILITY_PROPS} -Dquarkus.http.port=${httpPort}"
+}
+

--- a/modules/kogito-explainability/configure
+++ b/modules/kogito-explainability/configure
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+cp -v ${SOURCES_DIR}/kogito-explainability-runner.jar ${KOGITO_HOME}/bin/
+cp -rv ${ADDED_DIR}/launch/* ${KOGITO_HOME}/launch/
+
+chown -R 1001:0 ${KOGITO_HOME}
+chmod -R ug+rwX ${KOGITO_HOME}
+
+cp -v ${ADDED_DIR}/kogito-app-launch.sh ${KOGITO_HOME}
+chmod +x-w ${KOGITO_HOME}/kogito-app-launch.sh
+

--- a/modules/kogito-explainability/module.yaml
+++ b/modules/kogito-explainability/module.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+name: org.kie.kogito.explainability
+version: "0.13.0-rc1"
+
+artifacts:
+  - name: kogito-explainability-runner.jar
+    url: https://repository.jboss.org/nexus/content/groups/public/org/kie/kogito/explainability-service/8.0.0-SNAPSHOT/explainability-service-8.0.0-20200720.112616-115-runner.jar
+    md5: a85ebcc521ef22d5f9372f43cf2de5cf
+
+execute:
+  - script: configure
+

--- a/modules/kogito-explainability/tests/bats/kogito-explainability.bats
+++ b/modules/kogito-explainability/tests/bats/kogito-explainability.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+export KOGITO_HOME=/tmp/kogito
+export HOME=$KOGITO_HOME
+mkdir -p ${KOGITO_HOME}/launch
+cp $BATS_TEST_DIRNAME/../../../kogito-logging/added/logging.sh ${KOGITO_HOME}/launch/
+
+# imports
+load $BATS_TEST_DIRNAME/../../added/launch/kogito-explainability.sh
+
+teardown() {
+    rm -rf ${KOGITO_HOME}
+}
+
+
+@test "http port configuration default value" {
+    configure_explainability_http_port
+    expected=" -Dquarkus.http.port=8080"
+    echo "Result is ${KOGITO_EXPLAINABILITY_PROPS} and expected is ${expected}"
+    [ "${KOGITO_EXPLAINABILITY_PROPS}" = "${expected}" ]
+}
+
+@test "http port configuration custom value" {
+    export HTTP_PORT="9090"
+    configure_explainability_http_port
+    expected=" -Dquarkus.http.port=9090"
+    echo "Result is ${KOGITO_EXPLAINABILITY_PROPS} and expected is ${expected}"
+    [ "${KOGITO_EXPLAINABILITY_PROPS}" = "${expected}" ]
+}
+

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -8,7 +8,7 @@ import re
 from ruamel.yaml import YAML
 
 # All kogito-image modules that have the kogito version.
-MODULES = {"kogito-data-index", "kogito-image-dependencies",
+MODULES = {"kogito-data-index", "kogito-explainability", "kogito-image-dependencies",
            "kogito-infinispan-properties", "kogito-jobs-service",
            "kogito-jq", "kogito-kubernetes-client",
            "kogito-launch-scripts", "kogito-logging",

--- a/scripts/push-local-registry.sh
+++ b/scripts/push-local-registry.sh
@@ -4,7 +4,7 @@
 BUILD_ENGINE="docker"
 
 # All Kogito images
-IMAGES="kogito-quarkus-ubi8 kogito-quarkus-jvm-ubi8 kogito-quarkus-ubi8-s2i kogito-springboot-ubi8 kogito-springboot-ubi8-s2i kogito-data-index kogito-jobs-service kogito-management-console"
+IMAGES="kogito-quarkus-ubi8 kogito-quarkus-jvm-ubi8 kogito-quarkus-ubi8-s2i kogito-springboot-ubi8 kogito-springboot-ubi8-s2i kogito-data-index kogito-explainability kogito-jobs-service kogito-management-console"
 
 registry=${REGISTRY:-{1}}
 version=${2:-latest}

--- a/scripts/push-staging.py
+++ b/scripts/push-staging.py
@@ -18,6 +18,7 @@ import common
 # All Kogito images
 IMAGES = ["kogito-quarkus-ubi8", "kogito-quarkus-jvm-ubi8", "kogito-quarkus-ubi8-s2i",
           "kogito-springboot-ubi8", "kogito-springboot-ubi8-s2i", "kogito-data-index",
+          "kogito-explainability",
           "kogito-jobs-service", "kogito-management-console"]
 
 IMAGES_NEXT_RC_TAG = []

--- a/scripts/update-maven-information.py
+++ b/scripts/update-maven-information.py
@@ -27,6 +27,7 @@ Modules = {
     #service-name: module-name(directory in which module's module.yaml file is present)
     #Note: Service name should be same as given in the repository
     "data-index-service": "kogito-data-index",
+    "explainability-service": "kogito-explainability",
     "jobs-service": "kogito-jobs-service",
     "management-console": "kogito-management-console"
 }

--- a/tests/features/kogito-explainability.feature
+++ b/tests/features/kogito-explainability.feature
@@ -1,0 +1,29 @@
+@quay.io/kiegroup/kogito-explainability
+Feature: Kogito-explainability feature.
+
+  Scenario: verify if all labels are correctly set.
+    Given image is built
+    Then the image should contain label maintainer with value kogito <kogito@kiegroup.com>
+    And the image should contain label io.openshift.s2i.scripts-url with value image:///usr/local/s2i
+    And the image should contain label io.openshift.s2i.destination with value /tmp
+    And the image should contain label io.openshift.expose-services with value 8080:http
+    And the image should contain label io.k8s.description with value Runtime image for Kogito Explainability Service
+    And the image should contain label io.k8s.display-name with value Kogito Explainability Service
+    And the image should contain label io.openshift.tags with value kogito,explainability
+
+  Scenario: verify if the binary index is available on /home/kogito
+    When container is started with command bash
+    Then run sh -c 'ls /home/kogito/bin/kogito-explainability-runner.jar' in container and immediately check its output for /home/kogito/bin/kogito-explainability-runner.jar
+
+  Scenario: Verify if the debug is correctly enabled and test default http port
+    When container is started with env
+      | variable     | value |
+      | SCRIPT_DEBUG | true  |
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=8080 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-runner.jar
+
+  Scenario: Verify if the debug is correctly enabled and test custom http port
+    When container is started with env
+      | variable      | value |
+      | SCRIPT_DEBUG  | true  |
+      | HTTP_PORT     | 9090  |
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-runner.jar


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/KOGITO-2812

This PR aims to add the explainability service image. For more details about what we call "explainability service"
1) here you can find the PoC developed by the trusty team https://github.com/kiegroup/trusty-ai-sandbox/tree/master/end2endPoC/explanation-service . 
2) Here there is the scaffolding of the project in kogito-apps https://github.com/kiegroup/kogito-apps/tree/master/explainability-service
3) Here you can find the first open PR to add the explainability library (that will be used by the service) https://github.com/kiegroup/kogito-apps/pull/324

In particular the explainability service aims to provide explainability to the decisions taken by kogito runtime applications. 
The explainability service does not need persistence and it will be consumed by the trusty service. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster