### PR TITLE
KOGITO-2855 Version handled only in 1 script

### DIFF
--- a/scripts/manage-kogito-version.py
+++ b/scripts/manage-kogito-version.py
@@ -59,19 +59,8 @@ def update_test_apps_clone_repo(target_branch):
     print('Updating file {}'.format(file))
     if target_branch == 'master':
         os.system('sed -i \'s/^git checkout.*/git checkout master/\' ' + file)
-    elif 'x' in target_branch:
-        os.system('sed -i \'s/^git checkout.*/git checkout -b ' + target_branch + '/\' ' + file)
     else:
         os.system('sed -i \'s/^git checkout.*/git checkout -b ' + target_branch + ' ' + target_branch + '/\' ' + file)
-
-def update_python_scripts(target_version):
-    '''
-    Updates the clone-repo.sh script for adding the given repository URL to the Maven settings.
-    :param target_version: Maven Repository URL to set
-    '''
-    file = 'scripts/update-maven-information.py'
-    print('Updating file {}'.format(file))
-    os.system('sed -i \'s|^DEFAULT_VERSION = .*|DEFAULT_VERSION = \"{}\"|\' '.format(target_version) + file)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Kogito Version Manager')
@@ -108,7 +97,6 @@ if __name__ == "__main__":
             common.update_kogito_version_env_in_modules(args.bump_to)
             update_behave_tests(args.bump_to, tests_branch)
             update_test_apps_clone_repo(tests_branch)
-            update_python_scripts(args.bump_to)
         else:
             print("Provided version {0} does not match the expected regex - {1}".format(args.bump_to, pattern))
     else:

--- a/scripts/update-maven-information.py
+++ b/scripts/update-maven-information.py
@@ -19,8 +19,7 @@ import os
 import argparse
 
 DEFAULT_REPO_URL = "https://repository.jboss.org/nexus/content/groups/public/"
-DEFAULT_VERSION = "8.0.0-SNAPSHOT"
-DEFAULT_ARTIFACT_PATH = "org/kie/kogito"
+KOGITO_ARTIFACT_PATH = "org/kie/kogito"
 
 Modules = {
     #service-name: module-name(directory in which module's module.yaml file is present)
@@ -105,13 +104,12 @@ def update_artifacts(service,modulePath):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Update Maven information in repo from the given artifact url and version.')
     parser.add_argument('--repo-url', dest='repo_url', default=DEFAULT_REPO_URL, help='Defines the url of the repository to extract the artifacts from, defaults to {}'.format(DEFAULT_REPO_URL))
-    parser.add_argument('--version', dest='version', default=DEFAULT_VERSION, help='Defines the version of artifacts to retrieve from the repository url, defaults to {}'.format(DEFAULT_VERSION))
     args = parser.parse_args()
     
     # Update Kogito Service modules
     for serviceName, modulePath in Modules.items():
         service = {
-            "repo_url" : args.repo_url + "{}/{}/{}/".format(DEFAULT_ARTIFACT_PATH, serviceName, args.version),
+            "repo_url" : args.repo_url + "{}/{}/{}/".format(KOGITO_ARTIFACT_PATH, serviceName, args.version),
             "name" : serviceName,
             "version" : args.version
         }
@@ -119,6 +117,3 @@ if __name__ == "__main__":
         
         update_artifacts(service, moduleYamlFile)
         print("Successfully updated the artifacts for: ", serviceName)
-    
-    # Need also to set the KOGITO_VERSION for artifacts to the given one
-    common.update_kogito_version_env_in_modules(args.version)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-2855

Kogito version should be handled only `manage-kogito-version.py` script

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster