### PR TITLE
KOGITO-2995 - Update explainability jars

### DIFF
--- a/modules/kogito-explainability/added/kogito-app-launch.sh
+++ b/modules/kogito-explainability/added/kogito-app-launch.sh
@@ -19,7 +19,7 @@ CONFIGURE_SCRIPTS=(
 source ${KOGITO_HOME}/launch/configure.sh
 #############################################
 
-if [ "$EXPLAINABILITY_COMMUNICATION" = "rest" ] ; then 
+if [ ${EXPLAINABILITY_COMMUNICATION^^} = "REST" ] ; then 
       EXPLAINABILITY_JAR="kogito-explainability-rest-runner.jar"
     else
       EXPLAINABILITY_JAR="kogito-explainability-messaging-runner.jar"

--- a/modules/kogito-explainability/added/kogito-app-launch.sh
+++ b/modules/kogito-explainability/added/kogito-app-launch.sh
@@ -19,7 +19,13 @@ CONFIGURE_SCRIPTS=(
 source ${KOGITO_HOME}/launch/configure.sh
 #############################################
 
+if [ "$EXPLAINABILITY_COMMUNICATION" = "rest" ] ; then 
+      EXPLAINABILITY_JAR="kogito-explainability-rest-runner.jar"
+    else
+      EXPLAINABILITY_JAR="kogito-explainability-messaging-runner.jar"
+fi
+
 exec java ${SHOW_JVM_SETTINGS} ${JAVA_OPTIONS} ${KOGITO_EXPLAINABILITY_PROPS} \
         -Djava.library.path=$KOGITO_HOME/lib \
         -Dquarkus.http.host=0.0.0.0 \
-        -jar $KOGITO_HOME/bin/kogito-explainability-runner.jar
+        -jar $KOGITO_HOME/bin/$EXPLAINABILITY_JAR

--- a/modules/kogito-explainability/configure
+++ b/modules/kogito-explainability/configure
@@ -5,7 +5,8 @@ SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 
-cp -v ${SOURCES_DIR}/kogito-explainability-runner.jar ${KOGITO_HOME}/bin/
+cp -v ${SOURCES_DIR}/kogito-explainability-rest-runner.jar ${KOGITO_HOME}/bin/
+cp -v ${SOURCES_DIR}/kogito-explainability-messaging-runner.jar ${KOGITO_HOME}/bin/
 cp -rv ${ADDED_DIR}/launch/* ${KOGITO_HOME}/launch/
 
 chown -R 1001:0 ${KOGITO_HOME}

--- a/modules/kogito-explainability/module.yaml
+++ b/modules/kogito-explainability/module.yaml
@@ -3,10 +3,12 @@ name: org.kie.kogito.explainability
 version: "1.0.0-snapshot"
 
 artifacts:
-  - name: kogito-explainability-runner.jar
-    url: https://repository.jboss.org/nexus/content/groups/public/org/kie/kogito/explainability-service/1.0.0-SNAPSHOT/explainability-service-1.0.0-20200805.112339-4-runner.jar
-    md5: 562914e133231f088010ef2c9dd0f2c4
+  - name: kogito-explainability-rest-runner.jar
+    url: https://repository.jboss.org/nexus/content/groups/public/org/kie/kogito/explainability-service-rest/1.0.0-SNAPSHOT/explainability-service-rest-1.0.0-20200807.112159-1-runner.jar
+    md5: 6d4575cad75344c8855a3c186d4ce7de
+  - name: kogito-explainability-messaging-runner.jar
+    url: https://repository.jboss.org/nexus/content/groups/public/org/kie/kogito/explainability-service-messaging/1.0.0-SNAPSHOT/explainability-service-messaging-1.0.0-20200807.112136-1-runner.jar
+    md5: 0c81d8af996bcff1b9fbab187a4514b5
 
 execute:
   - script: configure
-

--- a/scripts/update-maven-artifacts.py
+++ b/scripts/update-maven-artifacts.py
@@ -28,7 +28,8 @@ Modules = {
     #Note: Service name should be same as given in the repository
     "data-index-service": "kogito-data-index",
     "trusty-service": "kogito-trusty",
-    "explainability-service": "kogito-explainability",
+    "explainability-service-rest": "kogito-explainability",
+    "explainability-service-messaging": "kogito-explainability",
     "jobs-service": "kogito-jobs-service",
     "management-console": "kogito-management-console"
 }
@@ -102,15 +103,17 @@ def checkUrl(url):
 
 def update_artifacts(service,modulePath):
     '''
-    Updates the module.yaml file of services with latest artifacts
+    Updates the module.yaml file of services with latest artifacts. When an image contains more than one jar, the correct one is selected by
+    checking if the name of the service is contained in the url of the artifact. 
     :param service: Service information (repo_url, version, name)
     :param modulePath: relative file location of the module.yaml for the kogito service
     '''
 
     with open(modulePath) as module:
         data=common.yaml_loader().load(module)
-        data['artifacts'][0]['url']=getRunnerURL(service)
-        data['artifacts'][0]['md5']=getMD5(service)
+        artifact = next(filter(lambda x: service['name'] in x['url'], data['artifacts']))
+        artifact['url']=getRunnerURL(service)
+        artifact['md5']=getMD5(service)
     with open(modulePath, 'w') as module:
         common.yaml_loader().dump(data, module)
 

--- a/tests/features/kogito-explainability.feature
+++ b/tests/features/kogito-explainability.feature
@@ -11,19 +11,32 @@ Feature: Kogito-explainability feature.
     And the image should contain label io.k8s.display-name with value Kogito Explainability Service
     And the image should contain label io.openshift.tags with value kogito,explainability
 
-  Scenario: verify if the binary index is available on /home/kogito
+  Scenario: verify if the messaging binary is available on /home/kogito
     When container is started with command bash
-    Then run sh -c 'ls /home/kogito/bin/kogito-explainability-runner.jar' in container and immediately check its output for /home/kogito/bin/kogito-explainability-runner.jar
+    Then run sh -c 'ls /home/kogito/bin/kogito-explainability-messaging-runner.jar' in container and immediately check its output for /home/kogito/bin/kogito-explainability-messaging-runner.jar
+
+  Scenario: verify if the rest binary is available on /home/kogito
+    When container is started with command bash
+    Then run sh -c 'ls /home/kogito/bin/kogito-explainability-rest-runner.jar' in container and immediately check its output for /home/kogito/bin/kogito-explainability-rest-runner.jar
 
   Scenario: Verify if the debug is correctly enabled and test default http port
     When container is started with env
       | variable     | value |
       | SCRIPT_DEBUG | true  |
-    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=8080 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-runner.jar
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=8080 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-messaging-runner.jar
 
   Scenario: Verify if the debug is correctly enabled and test custom http port
     When container is started with env
       | variable      | value |
       | SCRIPT_DEBUG  | true  |
       | HTTP_PORT     | 9090  |
-    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-runner.jar
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-messaging-runner.jar
+
+
+  Scenario: Verify if the explainability rest binary is selected by the enviroment variable EXPLAINABILITY_COMMUNICATION
+    When container is started with env
+      | variable      | value |
+      | EXPLAINABILITY_COMMUNICATION  | rest |
+      | SCRIPT_DEBUG  | true  |
+      | HTTP_PORT     | 9090  |
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-rest-runner.jar


### PR DESCRIPTION
Since two jars are now created for the explainability service (depending if the user would like to use the expl service with rest or with messages), the image has to be updated as well. 

The enviroment variable `EXPLAINABILITY_COMMUNICATION` let the user to select which jar to use. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster