### PR TITLE
KOGITO-3224 - Enable explainability messaging in trusty image

### DIFF
--- a/kogito-explainability-overrides.yaml
+++ b/kogito-explainability-overrides.yaml
@@ -20,7 +20,9 @@ envs:
   - name: "HTTP_PORT"
     example: "9090"
     description: "Defines which port the Explainability Container Image will listen on."
-
+  - name: "EXPLAINABILITY_COMMUNICATION"
+    example: "REST"
+    description: "Defines which kind of communication should be used by the Explainability Container: rest api or kafka events."
 ports:
 - value: 8080
 

--- a/modules/kogito-explainability/added/kogito-app-launch.sh
+++ b/modules/kogito-explainability/added/kogito-app-launch.sh
@@ -8,6 +8,7 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     SHOW_JVM_SETTINGS="-XshowSettings:properties"
     log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
     log_info "JVM settings debug is enabled."
+    printenv
 fi
 
 
@@ -19,13 +20,7 @@ CONFIGURE_SCRIPTS=(
 source ${KOGITO_HOME}/launch/configure.sh
 #############################################
 
-if [ "${EXPLAINABILITY_COMMUNICATION^^}" = "REST" ] ; then 
-      EXPLAINABILITY_JAR="kogito-explainability-rest-runner.jar"
-    else
-      EXPLAINABILITY_JAR="kogito-explainability-messaging-runner.jar"
-fi
-
 exec java ${SHOW_JVM_SETTINGS} ${JAVA_OPTIONS} ${KOGITO_EXPLAINABILITY_PROPS} \
         -Djava.library.path=$KOGITO_HOME/lib \
         -Dquarkus.http.host=0.0.0.0 \
-        -jar $KOGITO_HOME/bin/$EXPLAINABILITY_JAR
+        -jar $KOGITO_HOME/bin/$EXPLAINABILITY_SERVICE_JAR

--- a/modules/kogito-explainability/added/kogito-app-launch.sh
+++ b/modules/kogito-explainability/added/kogito-app-launch.sh
@@ -19,7 +19,7 @@ CONFIGURE_SCRIPTS=(
 source ${KOGITO_HOME}/launch/configure.sh
 #############################################
 
-if [ ${EXPLAINABILITY_COMMUNICATION^^} = "REST" ] ; then 
+if [ "${EXPLAINABILITY_COMMUNICATION^^}" = "REST" ] ; then 
       EXPLAINABILITY_JAR="kogito-explainability-rest-runner.jar"
     else
       EXPLAINABILITY_JAR="kogito-explainability-messaging-runner.jar"

--- a/modules/kogito-explainability/added/launch/kogito-explainability.sh
+++ b/modules/kogito-explainability/added/launch/kogito-explainability.sh
@@ -20,7 +20,7 @@ function configure_explainability_http_port {
 }
 
 function configure_explainability_jar {
-    local allowed_communication_types=("REST", "MESSAGING")
+    local allowed_communication_types=("REST" "MESSAGING")
     local communication="MESSAGING"
     if [[ ! "${allowed_communication_types[@]}" =~ "${EXPLAINABILITY_COMMUNICATION^^}" ]]; then
         log_warning "Explainability communication type ${EXPLAINABILITY_COMMUNICATION} is not allowed, the allowed types are [${allowed_communication_types[*]}]. Defaulting to ${communication}."

--- a/modules/kogito-explainability/added/launch/kogito-explainability.sh
+++ b/modules/kogito-explainability/added/launch/kogito-explainability.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 
+#import
+source ${KOGITO_HOME}/launch/logging.sh
 
 function prepareEnv() {
     # keep it on alphabetical order
+    unset EXPLAINABILITY_COMMUNICATION
     unset HTTP_PORT
 }
 
 function configure() {
     configure_explainability_http_port
+    configure_explainability_jar
 }
 
 function configure_explainability_http_port {
@@ -15,3 +19,15 @@ function configure_explainability_http_port {
     KOGITO_EXPLAINABILITY_PROPS="${KOGITO_EXPLAINABILITY_PROPS} -Dquarkus.http.port=${httpPort}"
 }
 
+function configure_explainability_jar {
+    local allowed_communication_types=("REST", "MESSAGING")
+    local communication="MESSAGING"
+    if [[ ! "${allowed_communication_types[@]}" =~ "${EXPLAINABILITY_COMMUNICATION^^}" ]]; then
+        log_warning "Explainability communication type ${EXPLAINABILITY_COMMUNICATION} is not allowed, the allowed types are [${allowed_communication_types[*]}]. Defaulting to ${communication}."
+    elif [ "${EXPLAINABILITY_COMMUNICATION^^}" == "REST" ]; then
+        communication="${EXPLAINABILITY_COMMUNICATION^^}"
+    fi
+
+    log_info "Explainability communication is set to ${communication}"
+    EXPLAINABILITY_SERVICE_JAR="kogito-explainability-${communication,,}-runner.jar"
+}

--- a/modules/kogito-explainability/tests/bats/kogito-explainability.bats
+++ b/modules/kogito-explainability/tests/bats/kogito-explainability.bats
@@ -28,3 +28,25 @@ teardown() {
     [ "${KOGITO_EXPLAINABILITY_PROPS}" = "${expected}" ]
 }
 
+@test "test if the default explainability communication type is correctly set" {
+    configure_explainability_jar
+    expected="kogito-explainability-messaging-runner.jar"
+    echo "result: ${EXPLAINABILITY_SERVICE_JAR} \n expected: ${expected}"
+    [ "${EXPLAINABILITY_SERVICE_JAR}" = "${expected}" ]
+}
+
+@test "test if explainability communication service default value is correctly set if a nonsense type is set" {
+    EXPLAINABILITY_COMMUNICATION="nonsense"
+    configure_explainability_jar
+    expected="kogito-explainability-messaging-runner.jar"
+    echo "result: ${EXPLAINABILITY_SERVICE_JAR} \n expected: ${expected}"
+    [ "${EXPLAINABILITY_SERVICE_JAR}" = "${expected}" ]
+}
+
+@test "test if explainability communication service default value s correctly set if set to rest" {
+    EXPLAINABILITY_COMMUNICATION="rest"
+    configure_explainability_jar
+    expected="kogito-explainability-rest-runner.jar"
+    echo "result: ${EXPLAINABILITY_SERVICE_JAR} \n expected: ${expected}"
+    [ "${EXPLAINABILITY_SERVICE_JAR}" = "${expected}" ]
+}

--- a/modules/kogito-trusty/added/launch/kogito-trusty.sh
+++ b/modules/kogito-trusty/added/launch/kogito-trusty.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+#import
+source ${KOGITO_HOME}/launch/logging.sh
 
 function prepareEnv() {
     # keep it on alphabetical order
@@ -18,9 +20,13 @@ function configure_trusty_http_port {
 }
 
 function enable_explainability {
-    local explainabilityEnabled=${EXPLAINABILITY_ENABLED:="true"}
-    if [ "${explainabilityEnabled^^}" = "FALSE" ] ; then 
-          explainabilityEnabled="false"
+    local allowed_values=("TRUE" "FALSE")
+    local explainability_enabled="true"
+    if [[ ! "${allowed_values[@]}" =~ "${EXPLAINABILITY_ENABLED^^}" ]]; then
+        log_warning "Explainability enabled type ${EXPLAINABILITY_ENABLED} is not allowed, the allowed types are [${allowed_values[*]}]. Defaulting to ${explainability_enabled}."
+    elif [ "${EXPLAINABILITY_ENABLED^^}" == "FALSE" ]; then
+        explainability_enabled="${EXPLAINABILITY_ENABLED^^}"
     fi
-    KOGITO_TRUSTY_PROPS="${KOGITO_TRUSTY_PROPS} -Dtrusty.explainability.enabled=${explainabilityEnabled}"
+    log_info "Explainability is enabled: ${explainability_enabled}"
+    KOGITO_TRUSTY_PROPS="${KOGITO_TRUSTY_PROPS} -Dtrusty.explainability.enabled=${explainability_enabled,,}"
 }

--- a/modules/kogito-trusty/added/launch/kogito-trusty.sh
+++ b/modules/kogito-trusty/added/launch/kogito-trusty.sh
@@ -18,7 +18,7 @@ function configure_trusty_http_port {
 }
 
 function enable_explainability {
-    local explainabilityEnabled=${EXPLAINABILITY_ENABLED:"true"}
+    local explainabilityEnabled=${EXPLAINABILITY_ENABLED:="true"}
     if [ "${explainabilityEnabled^^}" = "FALSE" ] ; then 
           explainabilityEnabled="false"
     fi

--- a/modules/kogito-trusty/added/launch/kogito-trusty.sh
+++ b/modules/kogito-trusty/added/launch/kogito-trusty.sh
@@ -18,11 +18,9 @@ function configure_trusty_http_port {
 }
 
 function enable_explainability {
-    local explainabilityEnabled=${EXPLAINABILITY_ENABLED^^}
-    if [ "${explainabilityEnabled}" = "FALSE" ] ; then 
-      explainabilityEnabled="false"
-    else
-      explainabilityEnabled="true"
+    local explainabilityEnabled=${EXPLAINABILITY_ENABLED:"true"}
+    if [ "${explainabilityEnabled^^}" = "TRUE" ] ; then 
+          explainabilityEnabled="true"
     fi
     KOGITO_TRUSTY_PROPS="${KOGITO_TRUSTY_PROPS} -Dtrusty.explainability.enabled=${explainabilityEnabled}"
 }

--- a/modules/kogito-trusty/added/launch/kogito-trusty.sh
+++ b/modules/kogito-trusty/added/launch/kogito-trusty.sh
@@ -19,8 +19,8 @@ function configure_trusty_http_port {
 
 function enable_explainability {
     local explainabilityEnabled=${EXPLAINABILITY_ENABLED:"true"}
-    if [ "${explainabilityEnabled^^}" = "TRUE" ] ; then 
-          explainabilityEnabled="true"
+    if [ "${explainabilityEnabled^^}" = "FALSE" ] ; then 
+          explainabilityEnabled="false"
     fi
     KOGITO_TRUSTY_PROPS="${KOGITO_TRUSTY_PROPS} -Dtrusty.explainability.enabled=${explainabilityEnabled}"
 }

--- a/modules/kogito-trusty/added/launch/kogito-trusty.sh
+++ b/modules/kogito-trusty/added/launch/kogito-trusty.sh
@@ -3,11 +3,13 @@
 
 function prepareEnv() {
     # keep it on alphabetical order
+    unset EXPLAINABILITY_ENABLED
     unset HTTP_PORT
 }
 
 function configure() {
     configure_trusty_http_port
+    enable_explainability
 }
 
 function configure_trusty_http_port {
@@ -15,3 +17,12 @@ function configure_trusty_http_port {
     KOGITO_TRUSTY_PROPS="${KOGITO_TRUSTY_PROPS} -Dquarkus.http.port=${httpPort}"
 }
 
+function enable_explainability {
+    local explainabilityEnabled=${EXPLAINABILITY_ENABLED^^}
+    if [ "${explainabilityEnabled}" = "FALSE" ] ; then 
+      explainabilityEnabled="false"
+    else
+      explainabilityEnabled="true"
+    fi
+    KOGITO_TRUSTY_PROPS="${KOGITO_TRUSTY_PROPS} -Dtrusty.explainability.enabled=${explainabilityEnabled}"
+}

--- a/modules/kogito-trusty/tests/bats/kogito-trusty.bats
+++ b/modules/kogito-trusty/tests/bats/kogito-trusty.bats
@@ -12,7 +12,6 @@ teardown() {
     rm -rf ${KOGITO_HOME}
 }
 
-
 @test "http port configuration default value" {
     configure_trusty_http_port
     expected=" -Dquarkus.http.port=8080"
@@ -28,3 +27,18 @@ teardown() {
     [ "${KOGITO_TRUSTY_PROPS}" = "${expected}" ]
 }
 
+
+@test "explainability is enabled by default" {
+    enable_explainability
+    expected=" -Dtrusty.explainability.enabled=true"
+    echo "Result is ${KOGITO_TRUSTY_PROPS} and expected is ${expected}"
+    [ "${KOGITO_TRUSTY_PROPS}" = "${expected}" ]
+}
+
+@test "disable explainability" {
+    export EXPLAINABILITY_ENABLED="false" 
+    enable_explainability
+    expected=" -Dtrusty.explainability.enabled=false"
+    echo "Result is ${KOGITO_TRUSTY_PROPS} and expected is ${expected}"
+    [ "${KOGITO_TRUSTY_PROPS}" = "${expected}" ]
+}

--- a/modules/kogito-trusty/tests/bats/kogito-trusty.bats
+++ b/modules/kogito-trusty/tests/bats/kogito-trusty.bats
@@ -42,3 +42,11 @@ teardown() {
     echo "Result is ${KOGITO_TRUSTY_PROPS} and expected is ${expected}"
     [ "${KOGITO_TRUSTY_PROPS}" = "${expected}" ]
 }
+
+@test "explainability is enabled even if nonsense values are provided" {
+    EXPLAINABILITY_ENABLED="nonsense"
+    enable_explainability
+    expected=" -Dtrusty.explainability.enabled=true"
+    echo "result: ${KOGITO_TRUSTY_PROPS} \n expected: ${expected}"
+    [ "${KOGITO_TRUSTY_PROPS}" = "${expected}" ]
+}

--- a/tests/features/kogito-explainability.feature
+++ b/tests/features/kogito-explainability.feature
@@ -47,4 +47,4 @@ Feature: Kogito-explainability feature.
       | variable               | value    |
       | SCRIPT_DEBUG           | true     |
       | EXPLAINABILITY_COMMUNICATION | nonsense |
-    Then container log should contain WARN Explainability communication type nonsense is not allowed, the allowed types are [REST, MESSAGING]. Defaulting to MESSAGING.
+    Then container log should contain WARN Explainability communication type nonsense is not allowed, the allowed types are [REST MESSAGING]. Defaulting to MESSAGING.

--- a/tests/features/kogito-explainability.feature
+++ b/tests/features/kogito-explainability.feature
@@ -14,6 +14,8 @@ Feature: Kogito-explainability feature.
   Scenario: verify if the messaging binary is available on /home/kogito
     When container is started with command bash
     Then run sh -c 'ls /home/kogito/bin/kogito-explainability-messaging-runner.jar' in container and immediately check its output for /home/kogito/bin/kogito-explainability-messaging-runner.jar
+    And run sh -c 'ls /home/kogito/bin/kogito-explainability-rest-runner.jar' in container and immediately check its output for /home/kogito/bin/kogito-explainability-rest-runner.jar
+
 
   Scenario: verify if the rest binary is available on /home/kogito
     When container is started with command bash
@@ -32,7 +34,6 @@ Feature: Kogito-explainability feature.
       | HTTP_PORT     | 9090  |
     Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-messaging-runner.jar
 
-
   Scenario: Verify if the explainability rest binary is selected by the enviroment variable EXPLAINABILITY_COMMUNICATION
     When container is started with env
       | variable      | value |
@@ -40,3 +41,10 @@ Feature: Kogito-explainability feature.
       | SCRIPT_DEBUG  | true  |
       | HTTP_PORT     | 9090  |
     Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-explainability-rest-runner.jar
+
+  Scenario: Verify if the communication is correctly set to its default value if a wrong communication type is set
+    When container is started with env
+      | variable               | value    |
+      | SCRIPT_DEBUG           | true     |
+      | EXPLAINABILITY_COMMUNICATION | nonsense |
+    Then container log should contain WARN Explainability communication type nonsense is not allowed, the allowed types are [REST, MESSAGING]. Defaulting to MESSAGING.

--- a/tests/features/kogito-trusty.feature
+++ b/tests/features/kogito-trusty.feature
@@ -19,14 +19,22 @@ Feature: Kogito-trusty feature.
     When container is started with env
       | variable     | value |
       | SCRIPT_DEBUG | true  |
-    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=8080 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-trusty-runner.jar
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=8080 -Dtrusty.explainability.enabled=true -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-trusty-runner.jar
 
   Scenario: Verify if the debug is correctly enabled and test custom http port
     When container is started with env
       | variable      | value |
       | SCRIPT_DEBUG  | true  |
       | HTTP_PORT     | 9090  |
-    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-trusty-runner.jar
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Dtrusty.explainability.enabled=true -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-trusty-runner.jar
+
+  Scenario: Verify if the explainability messaging is disabled
+    When container is started with env
+      | variable      | value |
+      | SCRIPT_DEBUG  | true  |
+      | HTTP_PORT     | 9090  |
+      | EXPLAINABILITY_ENABLED     | false  |
+    Then container log should contain + exec java -XshowSettings:properties -Dquarkus.http.port=9090 -Dtrusty.explainability.enabled=false -Djava.library.path=/home/kogito/lib -Dquarkus.http.host=0.0.0.0 -jar /home/kogito/bin/kogito-trusty-runner.jar
 
   Scenario: verify if auth is correctly set
     When container is started with env


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/KOGITO-3224

The explainability messaging has to be enabled in the trusty image. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster