### PR TITLE
[KOGITO-3461] Moved KOGITO_VERSION to image.yaml

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -21,6 +21,10 @@ modules:
   repositories:
     - path: modules
 
+envs:
+  - name: "KOGITO_VERSION"
+    value: "1.0.0-SNAPSHOT"
+
 packages:
   manager: microdnf
 

--- a/modules/kogito-quarkus-s2i/module.yaml
+++ b/modules/kogito-quarkus-s2i/module.yaml
@@ -4,7 +4,3 @@ version: "1.0.0-snapshot"
 
 execute:
   - script: configure
-
-envs:
-  - name: "KOGITO_VERSION"
-    value: "1.0.0-SNAPSHOT"

--- a/modules/kogito-springboot-s2i/module.yaml
+++ b/modules/kogito-springboot-s2i/module.yaml
@@ -4,7 +4,3 @@ version: "1.0.0-snapshot"
 
 execute:
   - script: configure
-
-envs:
-  - name: "KOGITO_VERSION"
-    value: "1.0.0-SNAPSHOT"

--- a/scripts/manage-kogito-version.py
+++ b/scripts/manage-kogito-version.py
@@ -58,8 +58,7 @@ if __name__ == "__main__":
             common.update_image_version(args.bump_to)
             common.update_image_stream(args.bump_to)
             common.update_modules_version(args.bump_to)
-            common.update_artifacts_version_env_in_modules(artifacts_version)
-            common.update_artifacts_version_in_python_scripts(artifacts_version)
+            common.update_artifacts_version_env_in_image(artifacts_version)
 
             # tests default values
             common.update_examples_ref_in_behave_tests(examples_ref)

--- a/scripts/update-maven-artifacts.py
+++ b/scripts/update-maven-artifacts.py
@@ -21,8 +21,6 @@ import argparse
 DEFAULT_REPO_URL = "https://repository.jboss.org/nexus/content/groups/public/"
 KOGITO_ARTIFACT_PATH = "org/kie/kogito"
 
-ARTIFACTS_VERSION = "1.0.0-SNAPSHOT"
-
 Modules = {
     #service-name: module-name(directory in which module's module.yaml file is present)
     #Note: Service name should be same as given in the repository
@@ -124,12 +122,15 @@ if __name__ == "__main__":
     parser.add_argument('--repo-url', dest='repo_url', default=DEFAULT_REPO_URL, help='Defines the url of the repository to extract the artifacts from, defaults to {}'.format(DEFAULT_REPO_URL))
     args = parser.parse_args()
     
+    artifactsVersion = common.retrieve_artifacts_version()
+    print("Retrieve artifacts version: ", artifactsVersion)
+
     # Update Kogito Service modules
     for serviceName, modulePath in Modules.items():
         service = {
-            "repo_url" : args.repo_url + "{}/{}/{}/".format(KOGITO_ARTIFACT_PATH, serviceName, ARTIFACTS_VERSION),
+            "repo_url" : args.repo_url + "{}/{}/{}/".format(KOGITO_ARTIFACT_PATH, serviceName, artifactsVersion),
             "name" : serviceName,
-            "version" : ARTIFACTS_VERSION
+            "version" : artifactsVersion
         }
         moduleYamlFile = "modules/{}/module.yaml".format(modulePath)
         


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3461

Main fix on master for [workaround done on 0.15.x](https://github.com/kiegroup/kogito-images/pull/236/files)

That way, it is easier to manage the artifacts version and we can have in all images the KOGITO_VERSION that is setup.

I know that this is only used in s2i build but it is no harm to have it for all images.
That way, we have another way to know which version should be used with the image.

Let me know what you think.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster