### PR TITLE
[KOGITO-3553] - Ignore Self signed certificates from maven while bui…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,11 @@ pipeline{
                     }
 
                     githubscm.checkoutIfExists('kogito-images', changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
+
+                    //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
+                    if(env.MAVEN_MIRROR_URL != ""){
+                        sh "python3 scripts/update-tests.py --ignore-self-signed-cert=True"
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,8 +39,8 @@ pipeline{
                     githubscm.checkoutIfExists('kogito-images', changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
 
                     //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
-                    if(env.MAVEN_MIRROR_URL != ""){
-                        sh "python3 scripts/update-tests.py --ignore-self-signed-cert=True"
+                    if(env.MAVEN_MIRROR_URL != ''){
+                        sh "python3 scripts/update-tests.py --ignore-self-signed-cert"
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline{
 
                     //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
                     if(env.MAVEN_MIRROR_URL != ''){
-                        sh "python3 scripts/update-tests.py --ignore-self-signed-cert"
+                        sh 'python3 scripts/update-tests.py --ignore-self-signed-cert'
                     }
                 }
             }

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -215,7 +215,7 @@ pipeline {
 
                     //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
                     if(env.MAVEN_MIRROR_URL != ''){
-                        updateTestsCommand += " --ignore-self-signed-cert"
+                        updateTestsCommand += ' --ignore-self-signed-cert'
                     }
                     // Launch update tests
                     sh updateTestsCommand

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -206,7 +206,7 @@ pipeline {
                     }
 
                     // Set kogito-examples to bot author/branch if release
-                    if(params.EXAMPLES_REF != ""){
+                    if(params.EXAMPLES_REF != ''){
                         updateTestsCommand += " --examples-ref ${params.EXAMPLES_REF}"
                     }
                     if(params.EXAMPLES_URI){
@@ -214,8 +214,8 @@ pipeline {
                     }
 
                     //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
-                    if(env.MAVEN_MIRROR_URL != ""){
-                        updateTestsCommand += --ignore-self-signed-cert=True
+                    if(env.MAVEN_MIRROR_URL != ''){
+                        updateTestsCommand += " --ignore-self-signed-cert"
                     }
                     // Launch update tests
                     sh updateTestsCommand

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -213,6 +213,10 @@ pipeline {
                         updateTestsCommand += " --examples-uri ${params.EXAMPLES_URI}"
                     }
 
+                    //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
+                    if(env.MAVEN_MIRROR_URL != ""){
+                        updateTestsCommand += --ignore-self-signed-cert=True
+                    }
                     // Launch update tests
                     sh updateTestsCommand
 

--- a/modules/kogito-maven/3.6.x/added/configure-maven.sh
+++ b/modules/kogito-maven/3.6.x/added/configure-maven.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+#Please keep them in alphabatical order
 function prepareEnv() {
     unset HTTP_PROXY_HOST
     unset HTTP_PROXY_PORT
@@ -7,8 +8,9 @@ function prepareEnv() {
     unset HTTP_PROXY_USERNAME
     unset HTTP_PROXY_NONPROXYHOSTS
     unset HTTPS_PROXY
-    unset MAVEN_MIRROR_URL
     unset MAVEN_DOWNLOAD_OUTPUT
+    unset MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE
+    unset MAVEN_MIRROR_URL
     unset MAVEN_REPO_ID
     unset MAVEN_REPO_LAYOUT
     unset MAVEN_REPO_RELEASES_ENABLED
@@ -25,6 +27,7 @@ function configure() {
     configure_proxy
     configure_mirrors
     configure_maven_download_output
+    ignore_maven_self_signed_certificates
     set_kogito_maven_repo
     add_maven_repo
 }
@@ -89,6 +92,12 @@ function configure_mirrors() {
 function configure_maven_download_output() {
     if [ "${MAVEN_DOWNLOAD_OUTPUT}" != "true" ]; then
         export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} --no-transfer-progress"
+    fi
+}
+
+function ignore_maven_self_signed_certificates() {
+    if [ "${MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE}" == "true" ]; then
+        export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true"
     fi
 }
 

--- a/modules/kogito-maven/3.6.x/module.yaml
+++ b/modules/kogito-maven/3.6.x/module.yaml
@@ -62,7 +62,9 @@ envs:
   - name: "MAVEN_REPOS"
     description: "Used to define multiple repositories, this env defines a prefix that will be used to create different repositories."
     example: "CENTRAL,INTERNAL"
-
+  - name: "MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE"
+    description: "When set, use of relaxed SSL check for user generated certificates. Default value is false"
+    example: "true"
 # unfortunately by now the version needs to be hardcoded.
 artifacts:
   - name: apache-maven-3.6.2-bin.tar.gz

--- a/modules/kogito-maven/tests/bats/maven-settings.bats
+++ b/modules/kogito-maven/tests/bats/maven-settings.bats
@@ -164,6 +164,27 @@ function _generate_random_id() {
     [ "${expected}" = "${result}" ]
 }
 
+@test "test maven args when IGNORE_SELF_SIGNED_CERTIFICATE is true" {
+    prepareEnv
+    MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE="true"
+    ignore_maven_self_signed_certificates
+    expected=" -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true"
+    result="${MAVEN_ARGS_APPEND}"
+    echo "expected=${expected}"
+    echo "result=${result}"
+    [ "${expected}" = "${result}" ]
+}
+
+@test "test maven args when IGNORE_SELF_SIGNED_CERTIFICATE is false" {
+    prepareEnv
+    ignore_maven_self_signed_certificates
+    expected=""
+    result="${MAVEN_ARGS_APPEND}"
+    echo "expected=${expected}"
+    echo "result=${result}"
+    [ "${expected}" = "${result}" ]
+}
+
 @test "test maven custom repo with ID and all supported configurations" {
     prepareEnv
     MAVEN_REPO_URL="http://my.cool.mvn.repo.severinolabs.com/group/public"

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -222,7 +222,15 @@ def update_maven_repo_in_behave_tests(repo_url, replaceJbossRepository):
         envVarKey = "JBOSS_MAVEN_REPO_URL"
     replacement = "| variable | value |\n      | {} | {} |\n      | MAVEN_DOWNLOAD_OUTPUT | true |".format(envVarKey, repo_url)
     update_in_behave_tests(pattern, replacement)
-
+def ignore_maven_self_signed_certificate_in_behave_tests():
+    """
+    Sets the enviornment variable to ignore the self-signed certificates in maven
+    """
+    print("Setting MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE env in behave tests")
+    pattern = re.compile('\|\s*variable[\s]*\|[\s]*value[\s]*\|')
+    replacement = "| variable | value |\n      | MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE | true |"
+    update_in_behave_tests(pattern, replacement)
+    
 def update_in_behave_tests(pattern, replacement):
     """
     Update all behave tests files

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -224,7 +224,7 @@ def update_maven_repo_in_behave_tests(repo_url, replaceJbossRepository):
     update_in_behave_tests(pattern, replacement)
 def ignore_maven_self_signed_certificate_in_behave_tests():
     """
-    Sets the enviornment variable to ignore the self-signed certificates in maven
+    Sets the environment variable to ignore the self-signed certificates in maven
     """
     print("Setting MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE env in behave tests")
     pattern = re.compile('\|\s*variable[\s]*\|[\s]*value[\s]*\|')

--- a/scripts/update-tests.py
+++ b/scripts/update-tests.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     parser.add_argument('--examples-uri', dest='examples_uri', help='To update the examples uri for testing')
     parser.add_argument('--examples-ref', dest='examples_ref', help='To update the examples ref for testing')
     parser.add_argument('--artifacts-version', dest='artifacts_version', help='To update the artifacts version for testing')
-    parser.add_argument('--ignore-self-signed-cert', dest='ignore_self_signed_cert', help='If set to true will relax the SSL for user-generated self-signed certificates', default=False)
+    parser.add_argument('--ignore-self-signed-cert', dest='ignore_self_signed_cert', default=False, action='store_true', help='If set to true will relax the SSL for user-generated self-signed certificates')
     args = parser.parse_args()
 
     if args.repo_url:

--- a/scripts/update-tests.py
+++ b/scripts/update-tests.py
@@ -17,6 +17,7 @@ if __name__ == "__main__":
     parser.add_argument('--examples-uri', dest='examples_uri', help='To update the examples uri for testing')
     parser.add_argument('--examples-ref', dest='examples_ref', help='To update the examples ref for testing')
     parser.add_argument('--artifacts-version', dest='artifacts_version', help='To update the artifacts version for testing')
+    parser.add_argument('--ignore-self-signed-cert', dest='ignore_self_signed_cert', help='If set to true will relax the SSL for user-generated self-signed certificates', default=False)
     args = parser.parse_args()
 
     if args.repo_url:
@@ -33,3 +34,6 @@ if __name__ == "__main__":
 
     if args.artifacts_version:
         common.update_artifacts_version_in_behave_tests(args.artifacts_version)
+    
+    if args.ignore_self_signed_cert:
+        common.ignore_maven_self_signed_certificate_in_behave_tests()


### PR DESCRIPTION
…lding images

The PR aims to provide a mechanism to relax the SSL for user-generated self-signed certificates, Currently, our image build fails when a user has a maven mirror with self-signed certificates, after the PR setting `MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE` to "true" relax the constraint making our image to build successfully with self-signed maven mirror's certificate. For more info please [see](https://stackoverflow.com/questions/21252800/how-to-tell-maven-to-disregard-ssl-errors-and-trusting-all-certs)
See: https://issues.redhat.com/browse/KOGITO-3553

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster