### PR TITLE
[KOGITO-3978] Promote job: remove useless verification input

### DIFF
--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -123,16 +123,6 @@ pipeline {
                         sh 'cat modules/kogito-task-console/module.yaml'
                         sh 'cat modules/kogito-trusty-ui/module.yaml'
 
-                        // Input for checking new artifacts have been set correctly
-                        withCredentials([string(credentialsId: 'KOGITO_CI_EMAIL_TO', variable: 'ZULIP_EMAIL')]) {
-                            emailext body: "Images' modules have been set with latest artifacts from JBoss repository.\n" +
-                                    "Please verify in the logs if it has been set correctly: ${env.BUILD_URL}console.\n" +
-                                    "And take your decision here: ${env.BUILD_URL}input",
-                                    subject: "[${getBuildBranch()}] Release Pipeline",
-                                    to: ZULIP_EMAIL
-                        }
-                        input message: 'Are the artifacts set correctly ?', ok: 'Yes'
-
                         try {
                             githubscm.commitChanges('Setup Maven artifacts to released ones')
                             githubscm.pushObject('origin', getPRSourceBranch(), getBotAuthorCredsID())


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3978

If there is any problem retrieving the artifacts, [update-maven-artifacts.py](https://github.com/kiegroup/kogito-images/blob/master/scripts/update-maven-artifacts.py) will anyway fail.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster