### PR TITLE
KOGITO-4070 - Remove image_metadata from images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,6 @@ As an example, let's execute the tests from the [kogito-s2i-core](modules/kogito
  $ bats modules/kogito-s2i-core/tests/bats/s2i-core.bats 
  ✓ test manage_incremental_builds
  ✓ test assemble_runtime no binaries
- ✓ test assemble_runtime with binaries binaries
  ✓ test runtime_assemble
  ✓ test runtime_assemble with binary builds
  ✓ test runtime_assemble with binary builds entire target!

--- a/README.md
+++ b/README.md
@@ -175,10 +175,6 @@ $ s2i build https://github.com/kiegroup/kogito-examples.git \
 ---> Installing jar file
 'target/rules-quarkus-helloworld-runner.jar' -> '/home/kogito/bin/rules-quarkus-helloworld-runner.jar'
 ---> Copying application libraries
----> [s2i-core] Copy image metadata file...
-'/tmp/src/target/image_metadata.json' -> '/tmp/.s2i/image_metadata.json'
-'/tmp/src/target/image_metadata.json' -> '/tmp/src/.s2i/image_metadata.json'
-'/tmp/src/target/image_metadata.json' -> '/home/kogito/bin/image_metadata.json'
 INFO ---> [persistence] Copying persistence files...
 INFO ---> [persistence] Skip copying files, persistence directory does not exist...
 Build completed successfully
@@ -542,10 +538,6 @@ removed 'process-springboot-example-tests.jar'
 removed 'process-springboot-example-sources.jar'
 removed 'process-springboot-example-test-sources.jar'
 -----> Copying uploaded files to /home/kogito
----> [s2i-core] Copy image metadata file...
-'/tmp/src/./image_metadata.json' -> '/tmp/.s2i/image_metadata.json'
-'/tmp/src/./image_metadata.json' -> '/tmp/src/.s2i/image_metadata.json'
-'/tmp/src/./image_metadata.json' -> '/home/kogito/bin/image_metadata.json'
 ---> Installing application binaries
 './process-springboot-example.jar' -> '/home/kogito/bin/process-springboot-example.jar'
 ...
@@ -1174,12 +1166,9 @@ As an example, let's execute the tests from the [kogito-s2i-core](modules/kogito
  ✓ test manage_incremental_builds
  ✓ test assemble_runtime no binaries
  ✓ test assemble_runtime with binaries binaries
- ✓ test assemble_runtime with binaries binaries and metadata
  ✓ test runtime_assemble
  ✓ test runtime_assemble with binary builds
  ✓ test runtime_assemble with binary builds entire target!
- ✓ test handle_image_metadata_json no metadata
- ✓ test handle_image_metadata_json with metadata
  ✓ test copy_kogito_app default java build no jar file present
  ✓ test copy_kogito_app default java build jar file present
  ✓ test copy_kogito_app default quarkus java build no jar file present

--- a/modules/kogito-quarkus-s2i/s2i/bin/assemble
+++ b/modules/kogito-quarkus-s2i/s2i/bin/assemble
@@ -33,8 +33,5 @@ build_kogito_app $QUARKUS_RUNTIME_TYPE
 # copy kogito app to "${KOGITO_HOME}"/bin dir
 copy_kogito_app
 
-# handle custom image-metadata.json
-handle_image_metadata_json
-
 # handle persistence files
 copy_persistence_files

--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -33,12 +33,6 @@ function manage_incremental_build() {
 
 
 function assemble_runtime() {
-    if [ -d ""${KOGITO_HOME}"/bin" ]; then
-        log_info "---> Application binaries found and ready to use"
-    else
-        log_error "---> Application binaries NOT found, failing build..."
-        exit 1
-    fi
     # handle persistence files
     move_persistence_files
 }

--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -35,16 +35,6 @@ function manage_incremental_build() {
 function assemble_runtime() {
     if [ -d ""${KOGITO_HOME}"/bin" ]; then
         log_info "---> Application binaries found and ready to use"
-
-        log_info "---> [s2i-core] Adding custom labels..."
-        if [ -e ""${KOGITO_HOME}"/bin/image_metadata.json" ]; then
-            mkdir -pv /tmp/.s2i
-            mkdir -pv /tmp/src/.s2i/
-            cp -v "${KOGITO_HOME}"/bin/image_metadata.json /tmp/.s2i/image_metadata.json
-            cp -v "${KOGITO_HOME}"/bin/image_metadata.json /tmp/src/.s2i/image_metadata.json
-        else
-            log_info "-----> Failed to copy metadata file, "${KOGITO_HOME}"/bin/image_metadata.json does not exist"
-        fi
     else
         log_error "---> Application binaries NOT found, failing build..."
         exit 1
@@ -82,7 +72,6 @@ function runtime_assemble() {
         log_info "-----> Copying uploaded files to "${KOGITO_HOME}""
         artifactDir="."
         ARTIFACT_DIR=$artifactDir
-        handle_image_metadata_json
         copy_kogito_app
         copy_persistence_files
     else
@@ -92,21 +81,6 @@ function runtime_assemble() {
     log_info "-----> Cleaning up s2i directory"
     rm -rfv ${S2I_DESTINATION_DIR}/src/*
 }
-
-
-function handle_image_metadata_json() {
-    log_info "---> [s2i-core] Copy image metadata file..."
-    if [ -e "/tmp/src/${artifactDir}/image_metadata.json" ]; then
-        mkdir /tmp/.s2i
-        mkdir -p /tmp/src/.s2i/
-        cp -v /tmp/src/$artifactDir/image_metadata.json /tmp/.s2i
-        cp -v /tmp/src/$artifactDir/image_metadata.json /tmp/src/.s2i
-        cp -v /tmp/src/$artifactDir/image_metadata.json "${KOGITO_HOME}"/bin
-    else
-        log_info "-----> Failed to copy metadata file, /tmp/src/${artifactDir}/image_metadata.json not found."
-    fi
-}
-
 
 function build_kogito_app() {
     local RUNTIME_TYPE="${1:-$QUARKUS_RUNTIME_TYPE}"

--- a/modules/kogito-s2i-core/tests/bats/s2i-core.bats
+++ b/modules/kogito-s2i-core/tests/bats/s2i-core.bats
@@ -102,7 +102,7 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[6]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
+    [ "${lines[5]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
 }
 
 @test "test runtime_assemble with binary builds native binary" {
@@ -115,7 +115,7 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[7]}" = "'./myapp-0.0.1-runner' -> '"${KOGITO_HOME}"/bin/myapp-0.0.1-runner'" ]
+    [ "${lines[6]}" = "'./myapp-0.0.1-runner' -> '"${KOGITO_HOME}"/bin/myapp-0.0.1-runner'" ]
 
     # Only runner is located in bin directory
     [ -f ""${KOGITO_HOME}"/bin/myapp-0.0.1-runner" ]
@@ -135,7 +135,7 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[8]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
+    [ "${lines[7]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
 }
 
 # Check that the irrelevant binaries are excluded

--- a/modules/kogito-s2i-core/tests/bats/s2i-core.bats
+++ b/modules/kogito-s2i-core/tests/bats/s2i-core.bats
@@ -69,36 +69,12 @@ teardown() {
 
     run assemble_runtime
 
-    rm -rf "${KOGITO_HOME}"/bin/image_metadata.json
     rm -rf "${KOGITO_HOME}"/bin/artifact.jar
 
     echo "result= ${lines[@]}"
 
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "---> Application binaries found and ready to use" ]
-    [ "${lines[1]}" = "---> [s2i-core] Adding custom labels..." ]
-    [ "${lines[2]}" = "-----> Failed to copy metadata file, "${KOGITO_HOME}"/bin/image_metadata.json does not exist" ]
-}
-
-
-@test "test assemble_runtime with binaries binaries and metadata" {
-    mkdir "${KOGITO_HOME}"/bin
-    touch "${KOGITO_HOME}"/bin/image_metadata.json
-    touch "${KOGITO_HOME}"/bin/artifact.jar
-
-    run assemble_runtime
-
-    echo "result= ${lines[@]}"
-
-    [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "---> Application binaries found and ready to use" ]
-    [ "${lines[1]}" = "---> [s2i-core] Adding custom labels..." ]
-    [ "${lines[2]}" = "mkdir: created directory '/tmp/.s2i'" ]
-    [ "${lines[3]}" = "mkdir: created directory '/tmp/src'" ]
-    [ "${lines[4]}" = "mkdir: created directory '/tmp/src/.s2i/'" ]
-    [ "${lines[5]}" = "'"${KOGITO_HOME}"/bin/image_metadata.json' -> '/tmp/.s2i/image_metadata.json'" ]
-    [ "${lines[6]}" = "'"${KOGITO_HOME}"/bin/image_metadata.json' -> '/tmp/src/.s2i/image_metadata.json'" ]
-
 }
 
 @test "test runtime_assemble" {
@@ -255,30 +231,6 @@ teardown() {
     [ ! -f ""${KOGITO_HOME}"/bin/myapp-0.0.1-tests.jar" ]
     [ ! -f ""${KOGITO_HOME}"/bin/myapp-0.0.1-tests-sources.jar" ]
     [ ! -f ""${KOGITO_HOME}"/bin/lib/mydependency-0.0.1.jar" ]
-}
-
-@test "test handle_image_metadata_json no metadata" {
-    mkdir -p /tmp/src/target
-    run handle_image_metadata_json
-
-    echo "result= ${lines[@]}"
-    [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "---> [s2i-core] Copy image metadata file..." ]
-    [ "${lines[1]}" = "-----> Failed to copy metadata file, /tmp/src/target/image_metadata.json not found." ]
-}
-
-
-@test "test handle_image_metadata_json with metadata" {
-    mkdir -p /tmp/src/target
-    touch /tmp/src/target/image_metadata.json
-    run handle_image_metadata_json
-
-    echo "result= ${lines[@]}"
-    [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "---> [s2i-core] Copy image metadata file..." ]
-    [ "${lines[1]}" = "'/tmp/src/target/image_metadata.json' -> '/tmp/.s2i/image_metadata.json'" ]
-    [ "${lines[2]}" = "'/tmp/src/target/image_metadata.json' -> '/tmp/src/.s2i/image_metadata.json'" ]
-    [ "${lines[3]}" = "'/tmp/src/target/image_metadata.json' -> '"${KOGITO_HOME}"/bin'" ]
 }
 
 @test "test copy_kogito_app default java build no jar file present" {

--- a/modules/kogito-s2i-core/tests/bats/s2i-core.bats
+++ b/modules/kogito-s2i-core/tests/bats/s2i-core.bats
@@ -102,7 +102,7 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[7]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
+    [ "${lines[6]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
 }
 
 @test "test runtime_assemble with binary builds native binary" {
@@ -115,7 +115,7 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[8]}" = "'./myapp-0.0.1-runner' -> '"${KOGITO_HOME}"/bin/myapp-0.0.1-runner'" ]
+    [ "${lines[7]}" = "'./myapp-0.0.1-runner' -> '"${KOGITO_HOME}"/bin/myapp-0.0.1-runner'" ]
 
     # Only runner is located in bin directory
     [ -f ""${KOGITO_HOME}"/bin/myapp-0.0.1-runner" ]
@@ -135,7 +135,7 @@ teardown() {
 
     echo "result= ${lines[@]}"
     [ "$status" -eq 0 ]
-    [ "${lines[9]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
+    [ "${lines[8]}" = "'./myapp.jar' -> '"${KOGITO_HOME}"/bin/myapp.jar'" ]
 }
 
 # Check that the irrelevant binaries are excluded

--- a/modules/kogito-s2i-core/tests/bats/s2i-core.bats
+++ b/modules/kogito-s2i-core/tests/bats/s2i-core.bats
@@ -57,8 +57,7 @@ teardown() {
 
 @test "test assemble_runtime no binaries" {
     run assemble_runtime
-    echo "result= ${lines[@]}"
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
 }
 
 @test "test runtime_assemble" {

--- a/modules/kogito-s2i-core/tests/bats/s2i-core.bats
+++ b/modules/kogito-s2i-core/tests/bats/s2i-core.bats
@@ -58,23 +58,7 @@ teardown() {
 @test "test assemble_runtime no binaries" {
     run assemble_runtime
     echo "result= ${lines[@]}"
-    [ "${lines[0]}" = "---> Application binaries NOT found, failing build..." ]
     [ "$status" -eq 1 ]
-}
-
-
-@test "test assemble_runtime with binaries binaries" {
-    mkdir "${KOGITO_HOME}"/bin
-    touch "${KOGITO_HOME}"/bin/artifact.jar
-
-    run assemble_runtime
-
-    rm -rf "${KOGITO_HOME}"/bin/artifact.jar
-
-    echo "result= ${lines[@]}"
-
-    [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "---> Application binaries found and ready to use" ]
 }
 
 @test "test runtime_assemble" {

--- a/modules/kogito-springboot-s2i/s2i/bin/assemble
+++ b/modules/kogito-springboot-s2i/s2i/bin/assemble
@@ -30,8 +30,5 @@ build_kogito_app $SPRINGBOOT_RUNTIME_TYPE
 # copy kogito app to "${KOGITO_HOME}"/bin dir
 copy_kogito_app
 
-# handle custom image-metadata.json
-handle_image_metadata_json
-
 # handle persistence files
 copy_persistence_files


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/KOGITO-4070

image_metadata.json is not used anymore on the operator (since many time?), so we can clean up a bit the death dependencies. 

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster