### PR TITLE
[KOGITO-3034][BXMSPROD-1094] Setup Jenkins DSL scripts

### DIFF
--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -1,0 +1,27 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Jenkins Tests
+
+on:
+  pull_request:
+    paths: 
+    - '.jenkins/**'
+    - 'Jenkinsfile*'
+
+jobs:
+  dsl-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout 
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+      
+    - name: Test DSL
+    # TODO to change back to kiegroup/master
+      run: cd .jenkins/dsl && ./test.sh setup_dsl radtriste

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bats/*
 /.*
 !.gitignore
 !.github
+!.jenkins
 /nbproject
 /*.ipr
 /*.iws

--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -1,0 +1,192 @@
+import org.kie.jenkins.jobdsl.templates.KogitoJobTemplate
+import org.kie.jenkins.jobdsl.KogitoConstants
+import org.kie.jenkins.jobdsl.Utils
+import org.kie.jenkins.jobdsl.KogitoJobType
+
+boolean isMainBranch() {
+    return "${GIT_BRANCH}" == "${GIT_MAIN_BRANCH}"
+}
+
+def getDefaultJobParams() {
+    return [
+        job: [
+            name: 'kogito-images'
+        ],
+        git: [
+            author: "${GIT_AUTHOR_NAME}",
+            branch: "${GIT_BRANCH}",
+            repository: 'kogito-images',
+            credentials: "${GIT_AUTHOR_CREDENTIALS_ID}",
+            token_credentials: "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}"
+        ]
+    ]
+}
+
+def getJobParams(String jobName, String jobFolder, String jenkinsfileName, String jobDescription = '') {
+    def jobParams = getDefaultJobParams()
+    jobParams.job.name = jobName
+    jobParams.job.folder = jobFolder
+    jobParams.jenkinsfile = jenkinsfileName
+    if (jobDescription) {
+        jobParams.job.description = jobDescription
+    }
+    return jobParams
+}
+
+def bddRuntimesPrFolder = "${KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER}/${KogitoConstants.KOGITO_DSL_RUNTIMES_BDD_FOLDER}"
+def nightlyBranchFolder = "${KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER}/${JOB_BRANCH_FOLDER}"
+def releaseBranchFolder = "${KogitoConstants.KOGITO_DSL_RELEASE_FOLDER}/${JOB_BRANCH_FOLDER}"
+
+if (isMainBranch()) {
+    folder(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
+
+    setupPrJob(KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER)
+
+    // For BDD runtimes PR job
+    folder(bddRuntimesPrFolder)
+
+    setupDeployJob(bddRuntimesPrFolder, KogitoJobType.PR)
+}
+
+// Branch jobs
+folder(KogitoConstants.KOGITO_DSL_NIGHTLY_FOLDER)
+folder(nightlyBranchFolder)
+setupDeployJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
+setupPromoteJob(nightlyBranchFolder, KogitoJobType.NIGHTLY)
+
+// No release directly on main branch
+if (!isMainBranch()) {
+    folder(KogitoConstants.KOGITO_DSL_RELEASE_FOLDER)
+    folder(releaseBranchFolder)
+    setupDeployJob(releaseBranchFolder, KogitoJobType.RELEASE)
+    setupPromoteJob(releaseBranchFolder, KogitoJobType.RELEASE)
+}
+
+/////////////////////////////////////////////////////////////////
+// Methods
+/////////////////////////////////////////////////////////////////
+
+void setupPrJob(String jobFolder) {
+    def jobParams = getDefaultJobParams()
+    jobParams.job.folder = jobFolder
+    KogitoJobTemplate.createPRJob(this, jobParams)
+}
+
+void setupDeployJob(String jobFolder, KogitoJobType jobType) {
+    def jobParams = getJobParams('kogito-images-deploy', jobFolder, 'Jenkinsfile.deploy', 'Kogito Images Deploy')
+    if (jobType == KogitoJobType.PR) {
+        jobParams.git.branch = '${GIT_BRANCH_NAME}'
+        jobParams.git.author = '${GIT_AUTHOR}'
+        jobParams.git.project_url = Utils.createProjectUrl("${GIT_AUTHOR_NAME}", jobParams.git.repository)
+    }
+    KogitoJobTemplate.createPipelineJob(this, jobParams).with {
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+            if (jobType == KogitoJobType.PR) {
+                // author can be changed as param only for PR behavior, due to source branch/target, else it is considered as an env
+                stringParam('GIT_AUTHOR', "${GIT_AUTHOR_NAME}", 'Set the Git author to checkout')
+            }
+
+            // Build&Test information
+            booleanParam('SKIP_TESTS', false, 'Skip tests')
+            stringParam('EXAMPLES_URI', '', 'Git uri to the kogito-examples repository to use for tests.')
+            stringParam('EXAMPLES_REF', '', 'Git reference (branch/tag) to the kogito-examples repository to use for tests.')
+
+            // Deploy information
+            booleanParam('IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('QUAY_TOKEN_CREDENTIALS', '', 'quay.io access token credentials to use to push/pull images and set images\' visibility. Will be ignored if IMAGE_REGISTRY is different from quay.io. Else IMAGE_REGISTRY_CREDENTIALS is ignored if that one is set.')
+            stringParam('IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS_NIGHTLY}", 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            stringParam('IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Image registry to use to deploy images')
+            stringParam('IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
+            stringParam('IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
+            stringParam('IMAGE_TAG', '', 'Image tag to use to deploy images')
+
+            // Release information
+            stringParam('PROJECT_VERSION', '', 'Optional if not RELEASE. If RELEASE, cannot be empty.')
+            stringParam('KOGITO_ARTIFACTS_VERSION', '', 'Optional. If artifacts\' version is different from PROJECT_VERSION.')
+
+            booleanParam('CREATE_PR', false, 'In case of not releasing, you can ask to create a PR with the changes')
+        }
+
+        environmentVariables {
+            env('CI', true)
+            env('REPO_NAME', 'kogito-images')
+            env('PROPERTIES_FILE_NAME', 'deployment.properties')
+
+            env('RELEASE', jobType == KogitoJobType.RELEASE)
+            env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+
+            if (jobType == KogitoJobType.PR) {
+                env('MAVEN_ARTIFACT_REPOSITORY', "${MAVEN_PR_CHECKS_REPOSITORY_URL}")
+            } else {
+                env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
+
+                env('AUTHOR_CREDS_ID', "${GIT_AUTHOR_CREDENTIALS_ID}")
+                env('GITHUB_TOKEN_CREDS_ID', "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}")
+                env('GIT_AUTHOR_BOT', "${GIT_BOT_AUTHOR_NAME}")
+                env('BOT_CREDENTIALS_ID', "${GIT_BOT_AUTHOR_CREDENTIALS_ID}")
+
+                env('MAVEN_ARTIFACT_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+                env('DEFAULT_STAGING_REPOSITORY', "${MAVEN_NEXUS_STAGING_PROFILE_URL}")
+            }
+        }
+    }
+}
+
+void setupPromoteJob(String jobFolder, KogitoJobType jobType) {
+    KogitoJobTemplate.createPipelineJob(this, getJobParams('kogito-images-promote', jobFolder, 'Jenkinsfile.promote', 'Kogito Images Promote')).with {
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_BRANCH_NAME', "${GIT_BRANCH}", 'Set the Git branch to checkout')
+
+            // Deploy job url to retrieve deployment.properties
+            stringParam('DEPLOY_BUILD_URL', '', 'URL to jenkins deploy build to retrieve the `deployment.properties` file. If base parameters are defined, they will override the `deployment.properties` information')
+
+            // Base images information which can override `deployment.properties`
+            booleanParam('BASE_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Override `deployment.properties`. Set to true if base image should be retrieved from Openshift registry.In this case, BASE_IMAGE_REGISTRY_CREDENTIALS, BASE_IMAGE_REGISTRY and BASE_IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('BASE_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS_NIGHTLY}", 'Override `deployment.properties`. Base Image registry credentials to use to deploy images. Will be ignored if no BASE_IMAGE_REGISTRY is given')
+            stringParam('BASE_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Override `deployment.properties`. Base image registry')
+            stringParam('BASE_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Override `deployment.properties`. Base image namespace')
+            stringParam('BASE_IMAGE_NAME_SUFFIX', '', 'Override `deployment.properties`. Base image name suffix')
+            stringParam('BASE_IMAGE_TAG', '', 'Override `deployment.properties`. Base image tag')
+
+            // Promote images information
+            booleanParam('PROMOTE_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if base image should be deployed in Openshift registry.In this case, PROMOTE_IMAGE_REGISTRY_CREDENTIALS, PROMOTE_IMAGE_REGISTRY and PROMOTE_IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('PROMOTE_QUAY_TOKEN_CREDENTIALS', '', 'quay.io access token credentials to use to set images\' visibility. Will be ignored if PROMOTE_IMAGE_REGISTRY is different from quay.io.')
+            stringParam('PROMOTE_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS_NIGHTLY}", 'Promote Image registry credentials to use to deploy images. Will be ignored if no PROMOTE_IMAGE_REGISTRY is given')
+            stringParam('PROMOTE_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Promote image registry')
+            stringParam('PROMOTE_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Promote image namespace')
+            stringParam('PROMOTE_IMAGE_NAME_SUFFIX', '', 'Promote image name suffix')
+            stringParam('PROMOTE_IMAGE_TAG', '', 'Promote image tag')
+            booleanParam('DEPLOY_WITH_LATEST_TAG', false, 'Set to true if you want the deployed images to also be with the `latest` tag')
+
+            // Release information which can override `deployment.properties`
+            stringParam('PROJECT_VERSION', '', 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
+            stringParam('KOGITO_ARTIFACTS_VERSION', '', 'Optional. If artifacts\' version is different from PROJECT_VERSION.')
+            stringParam('GIT_TAG', '', 'Git tag to set, if different from PROJECT_VERSION')
+            stringParam('RELEASE_NOTES', '', 'Release notes to be added. If none provided, a default one will be given.')
+        }
+
+        environmentVariables {
+            env('CI', true)
+            env('REPO_NAME', 'kogito-images')
+            env('PROPERTIES_FILE_NAME', 'deployment.properties')
+
+            env('RELEASE', jobType == KogitoJobType.RELEASE)
+            env('JENKINS_EMAIL_CREDS_ID', "${JENKINS_EMAIL_CREDS_ID}")
+
+            env('GIT_AUTHOR', "${GIT_AUTHOR_NAME}")
+
+            env('AUTHOR_CREDS_ID', "${GIT_AUTHOR_CREDENTIALS_ID}")
+            env('GITHUB_TOKEN_CREDS_ID', "${GIT_AUTHOR_TOKEN_CREDENTIALS_ID}")
+            env('GIT_AUTHOR_BOT', "${GIT_BOT_AUTHOR_NAME}")
+            env('BOT_CREDENTIALS_ID', "${GIT_BOT_AUTHOR_CREDENTIALS_ID}")
+
+            env('DEFAULT_STAGING_REPOSITORY', "${MAVEN_NEXUS_STAGING_PROFILE_URL}")
+            env('MAVEN_ARTIFACT_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+        }
+    }
+}

--- a/.jenkins/dsl/test.sh
+++ b/.jenkins/dsl/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+TEMP_DIR=`mktemp -d`
+
+branch=$1
+author=$2
+
+if [ -z $branch ]; then
+  branch='master'
+fi
+
+if [ -z $author ]; then
+  author='kiegroup'
+fi
+
+echo '----- Cloning main dsl pipelines repo'
+git clone --single-branch --branch $branch https://github.com/${author}/kogito-pipelines.git $TEMP_DIR
+
+echo '----- Launching seed tests'
+${TEMP_DIR}/dsl/seed/scripts/seed_test.sh ${TEMP_DIR}

--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -15,48 +15,18 @@ pipeline {
     }
 
     options {
-        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
         timeout(time: 120, unit: 'MINUTES')
     }
 
-    parameters {
-        string(name: 'DISPLAY_NAME', defaultValue: '', description: 'Setup a specific build display name')
-
-        // Git information
-        string(name: 'BUILD_BRANCH_NAME', defaultValue: 'master', description: 'Which branch to build ? Set if you are not on a multibranch pipeline.')
-        string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
-
-        // Build&Test information
-        booleanParam(name: 'SKIP_TESTS', defaultValue: false, description: 'Skip tests')
-        string(name: 'MAVEN_ARTIFACT_REPOSITORY', defaultValue: '', description: 'Maven repository where the build artifacts are present')
-        string(name: 'EXAMPLES_URI', defaultValue: '', description: 'Git uri to the kogito-examples repository to use for tests.')
-        string(name: 'EXAMPLES_REF', defaultValue: '', description: 'Git reference (branch/tag) to the kogito-examples repository to use for tests.')
-
-        // Deploy information
-        booleanParam(name: 'IMAGE_USE_OPENSHIFT_REGISTRY', defaultValue: false, description: 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
-        string(name: 'QUAY_TOKEN_CREDENTIALS', defaultValue: '', description: 'quay.io access token credentials to use to push/pull images and set images\' visibility. Will be ignored if IMAGE_REGISTRY is different from quay.io. Else IMAGE_REGISTRY_CREDENTIALS is ignored if that one is set.')
-        string(name: 'IMAGE_REGISTRY_CREDENTIALS', defaultValue: '', description: 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
-        string(name: 'IMAGE_REGISTRY', defaultValue: '', description: 'Image registry to use to deploy images')
-        string(name: 'IMAGE_NAMESPACE', defaultValue: 'kiegroup', description: 'Image namespace to use to deploy images')
-        string(name: 'IMAGE_NAME_SUFFIX', defaultValue: '', description: 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
-        string(name: 'IMAGE_TAG', defaultValue: '', description: 'Image tag to use to deploy images')
-
-        // Release information
-        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Is this build for a release?')
-        string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Optional if not RELEASE. If RELEASE, cannot be empty.')
-        string(name: 'KOGITO_ARTIFACTS_VERSION', defaultValue: '', description: 'Optional. If artifacts\' version is different from PROJECT_VERSION.')
-
-        booleanParam(name: 'CREATE_CHANGES_PR', defaultValue: false, description: 'In case of not releasing, you can ask to create a PR with the changes')
-
-        // Bot author information. Set as params for easy testing.
-        string(name: 'GIT_AUTHOR_BOT', defaultValue: 'bsig-gh-bot', description: 'From which author should the PR be created ?')
-        string(name: 'BOT_CREDENTIALS_ID', defaultValue: 'bsig-gh-bot', description: 'Credentials for PR creation')
-    }
+    // parameters {
+    // For parameters, check into .jenkins/dsl/jobs.groovy file
+    // }
 
     environment {
-        KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
+        // Static env is defined into .jenkins/dsl/jobs.groovy file
 
-        CI = true
+        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+
         JAVA_HOME = "${GRAALVM_HOME}"
 
         OPENSHIFT_API = credentials('OPENSHIFT_API')
@@ -72,7 +42,7 @@ pipeline {
                 script {
                     clean()
 
-                    if (params.DISPLAY_NAME != '') {
+                    if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
@@ -85,7 +55,9 @@ pipeline {
                     checkoutRepo()
 
                     if (isRelease()) {
-                        assert getProjectVersion() != ''
+                        // Verify version is set and if on right release branch
+                        assert getProjectVersion()
+                        assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
                 }
             }
@@ -278,7 +250,7 @@ pipeline {
                 success {
                     script {
                         // Store image deployment information
-                        String imgPrefix = 'kogito-images.image'
+                        String imgPrefix = "${getRepoName()}.image"
                         setDeployPropertyIfNeeded("${imgPrefix}.registry", getDeployImageRegistry())
                         setDeployPropertyIfNeeded("${imgPrefix}.namespace", getDeployImageNamespace())
                         setDeployPropertyIfNeeded("${imgPrefix}.name-suffix", getDeployImageNameSuffix())
@@ -300,25 +272,26 @@ pipeline {
                     def commitMsg = "[${getBuildBranch()}] Update Maven artifacts"
                     def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}."
                     if (isRelease()) {
-                        commitMsg = "[${getBuildBranch()}] Update project version to ${getProjectVersion()} for release"
-                        prBody += '\nPlease do not merge, it will be merged automatically after testing.'
+                        commitMsg = "[${getBuildBranch()}] Update project version to ${getProjectVersion()}"
+                        prBody += '\nPlease do not merge, it should be merged automatically.'
                     }
                     String prLink = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
-                    deployProperties['kogito-images.pr.link'] = prLink
+                    deployProperties["${getRepoName()}.pr.link"] = prLink
 
                     if (isCreateChangesPR()) {
                         String bodyMsg = "PR has been created with update Maven artifacts.\nPlease review it here: ${prLink}"
 
-                        emailext body: bodyMsg, subject: "[${getBuildBranch()}][d] Kogito Images pipeline", to: env.KOGITO_CI_EMAIL_TO }
+                        emailext body: bodyMsg, subject: "[${getBuildBranch()}][d] Kogito Images pipeline", to: env.KOGITO_CI_EMAIL_TO 
+                    }
                 }
             }
             post {
                 success {
                     script {
-                        setDeployPropertyIfNeeded('kogito-images.pr.source.uri', "https://github.com/${getBotAuthor()}/kogito-images")
-                        setDeployPropertyIfNeeded('kogito-images.pr.source.ref', getBotBranch())
-                        setDeployPropertyIfNeeded('kogito-images.pr.target.uri', "https://github.com/${getGitAuthor()}/kogito-images")
-                        setDeployPropertyIfNeeded('kogito-images.pr.target.ref', getBuildBranch())
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.source.uri", "https://github.com/${getBotAuthor()}/${getRepoName()}")
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.source.ref", getBotBranch())
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.target.uri", "https://github.com/${getGitAuthor()}/${getRepoName()}")
+                        setDeployPropertyIfNeeded("${getRepoName()}.pr.target.ref", getBuildBranch())
                     }
                 }
             }
@@ -328,8 +301,8 @@ pipeline {
         always {
             script {
                 def propertiesStr = deployProperties.collect { entry -> "${entry.key}=${entry.value}" }.join('\n')
-                writeFile( file : 'deployment.properties' , text : propertiesStr)
-                archiveArtifacts artifacts: 'deployment.properties', allowEmptyArchive:true
+                writeFile( file : env.PROPERTIES_FILE_NAME , text : propertiesStr)
+                archiveArtifacts artifacts: env.PROPERTIES_FILE_NAME, allowEmptyArchive:true
                 clean()
             }
         }
@@ -338,7 +311,7 @@ pipeline {
 
 void checkoutRepo() {
     deleteDir()
-    checkout(githubscm.resolveRepository('kogito-images', getGitAuthor(), getBuildBranch(), false))
+    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
 }
 
 void commitChanges(String commitMsg) {
@@ -507,11 +480,15 @@ String getWorkspacePath(String image) {
 ////////////////////////////////////////////////////////////////////////
 
 boolean isRelease() {
-    return params.RELEASE
+    return env.RELEASE.toBoolean()
+}
+
+String getRepoName() {
+    return env.REPO_NAME
 }
 
 boolean isCreateChangesPR() {
-    return params.CREATE_CHANGES_PR
+    return params.CREATE_PR
 }
 
 String getBuildBranch() {
@@ -519,7 +496,7 @@ String getBuildBranch() {
 }
 
 String getGitAuthor() {
-    return params.GIT_AUTHOR
+    return "${GIT_AUTHOR}"
 }
 
 String getBotBranch() {
@@ -527,11 +504,11 @@ String getBotBranch() {
 }
 
 String getBotAuthor() {
-    return params.GIT_AUTHOR_BOT
+    return env.GIT_AUTHOR_BOT
 }
 
 String getBotAuthorCredsID() {
-    return params.BOT_CREDENTIALS_ID
+    return env.BOT_CREDENTIALS_ID
 }
 
 String getProjectVersion() {
@@ -543,7 +520,7 @@ String getKogitoArtifactsVersion() {
 }
 
 String getMavenArtifactRepository() {
-    return params.MAVEN_ARTIFACT_REPOSITORY
+    return env.MAVEN_ARTIFACT_REPOSITORY ?: (isRelease() ? env.DEFAULT_STAGING_REPOSITORY : '')
 }
 
 boolean shouldSkipTests() {

--- a/Jenkinsfile.promote
+++ b/Jenkinsfile.promote
@@ -9,58 +9,16 @@ pipeline {
     }
 
     options {
-        buildDiscarder logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '10')
         timeout(time: 120, unit: 'MINUTES')
     }
-
-    parameters {
-        string(name: 'DISPLAY_NAME', defaultValue: '', description: 'Setup a specific build display name')
-
-        // Deploy job url to retrieve deployment.properties
-        string(name: 'DEPLOY_BUILD_URL', defaultValue: '', description: 'URL to jenkins deploy build to retrieve the `deployment.properties` file. If base parameters are defined, they will override the `deployment.properties` information')
-
-        // Git information which can override `deployment.properties`
-        string(name: 'BUILD_BRANCH_NAME', defaultValue: '', description: 'Override `deployment.properties`. Which branch to build? Set if you are not on a multibranch pipeline.')
-        string(name: 'GIT_AUTHOR', defaultValue: '', description: 'Override `deployment.properties`. Which Git author repository ?')
-
-        // Base images information which can override `deployment.properties`
-        booleanParam(name: 'BASE_IMAGE_USE_OPENSHIFT_REGISTRY', defaultValue: false, description: 'Override `deployment.properties`. Set to true if base image should be retrieved from Openshift registry.In this case, BASE_IMAGE_REGISTRY_CREDENTIALS, BASE_IMAGE_REGISTRY and BASE_IMAGE_NAMESPACE parameters will be ignored')
-        string(name: 'BASE_IMAGE_REGISTRY_CREDENTIALS', defaultValue: '', description: 'Override `deployment.properties`. Base Image registry credentials to use to deploy images. Will be ignored if no BASE_IMAGE_REGISTRY is given')
-        string(name: 'BASE_IMAGE_REGISTRY', defaultValue: '', description: 'Override `deployment.properties`. Base image registry')
-        string(name: 'BASE_IMAGE_NAMESPACE', defaultValue: '', description: 'Override `deployment.properties`. Base image namespace')
-        string(name: 'BASE_IMAGE_NAME_SUFFIX', defaultValue: '', description: 'Override `deployment.properties`. Base image name suffix')
-        string(name: 'BASE_IMAGE_TAG', defaultValue: '', description: 'Override `deployment.properties`. Base image tag')
-
-        // Promote images information
-        booleanParam(name: 'PROMOTE_IMAGE_USE_OPENSHIFT_REGISTRY', defaultValue: false, description: 'Set to true if base image should be deployed in Openshift registry.In this case, PROMOTE_IMAGE_REGISTRY_CREDENTIALS, PROMOTE_IMAGE_REGISTRY and PROMOTE_IMAGE_NAMESPACE parameters will be ignored')
-        string(name: 'PROMOTE_QUAY_TOKEN_CREDENTIALS', defaultValue: '', description: 'quay.io access token credentials to use to set images\' visibility. Will be ignored if PROMOTE_IMAGE_REGISTRY is different from quay.io.')
-        string(name: 'PROMOTE_IMAGE_REGISTRY_CREDENTIALS', defaultValue: '', description: 'Promote Image registry credentials to use to deploy images. Will be ignored if no PROMOTE_IMAGE_REGISTRY is given')
-        string(name: 'PROMOTE_IMAGE_REGISTRY', defaultValue: '', description: 'Promote image registry')
-        string(name: 'PROMOTE_IMAGE_NAMESPACE', defaultValue: '', description: 'Promote image namespace')
-        string(name: 'PROMOTE_IMAGE_NAME_SUFFIX', defaultValue: '', description: 'Promote image name suffix')
-        string(name: 'PROMOTE_IMAGE_TAG', defaultValue: '', description: 'Promote image tag')
-        booleanParam(name: 'DEPLOY_WITH_LATEST_TAG', defaultValue: false, description: 'Set to true if you want the deployed images to also be with the `latest` tag')
-
-        // Release information which can override `deployment.properties`
-        booleanParam(name: 'RELEASE', defaultValue: false, description: 'Override `deployment.properties`. Is this build for a release?')
-        string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Override `deployment.properties`. Optional if not RELEASE. If RELEASE, cannot be empty.')
-        string(name: 'KOGITO_ARTIFACTS_VERSION', defaultValue: '', description: 'Optional. If artifacts\' version is different from PROJECT_VERSION.')
-        string(name: 'GIT_TAG', defaultValue: '', description: 'Git tag to set, if different from PROJECT_VERSION')
-        string(name: 'MAVEN_ARTIFACT_REPOSITORY', defaultValue: '', description: 'Maven repository where the released jar artifacts are present. To be set if git author is not `kiegroup` and repository is different from JBoss repository.')
-        string(name: 'RELEASE_NOTES', defaultValue: '', description: 'Release notes to be added. If none provided, a default one will be given.')
-
-        // Bot author information. Set as params for easy testing.
-        string(name: 'BOT_CREDENTIALS_ID', defaultValue: 'bsig-gh-bot', description: 'Credentials for PR creation')
-
-        // Main author creds
-        string(name: 'AUTHOR_CREDS_ID', defaultValue: 'kie-ci', description: 'Credentials for PR merge')
-        string(name: 'GITHUB_TOKEN_CREDS_ID', defaultValue: 'kie-ci2-token', description: 'GH token to be used with GH CLI')
-    }
+    // parameters {
+    // For parameters, check into .jenkins/dsl/jobs.groovy file
+    // }
 
     environment {
-        KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
-
-        CI = true // Used by scripts
+        // Static env is defined into .jenkins/dsl/jobs.groovy file
+        
+        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         OPENSHIFT_API = credentials('OPENSHIFT_API')
         OPENSHIFT_REGISTRY = credentials('OPENSHIFT_REGISTRY')
@@ -68,7 +26,7 @@ pipeline {
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
 
-        GITHUB_REPO = 'kogito-images' // for github-release cli
+        GITHUB_REPO = "${REPO_NAME}" // for github-release cli
     }
 
     stages {
@@ -77,17 +35,19 @@ pipeline {
                 script {
                     clean()
 
-                    if (params.DISPLAY_NAME != '') {
+                    if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
 
                     readDeployProperties()
 
                     if (isRelease()) {
-                        assert getProjectVersion() != ''
+                        // Verify version is set and if on right release branch
+                        assert getProjectVersion()
+                        assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
 
-                    dir('kogito-images') {
+                    dir(getRepoName()) {
                         checkoutRepo()
                     }
 
@@ -102,7 +62,7 @@ pipeline {
             steps {
                 script {
                     // Update maven information with new artifacts from Maven central in the PR
-                    dir('kogito-images-update') {
+                    dir("artifacts-update") {
                         checkoutRepo()
                         githubscm.forkRepo(getBotAuthorCredsID())
 
@@ -150,7 +110,7 @@ pipeline {
                     } else if (getOldImageRegistryCredentials() != '') {
                         loginContainerRegistry(getOldImageRegistry(), getOldImageRegistryCredentials())
                     }
-                    dir('kogito-images') {
+                    dir(getRepoName()) {
                         pullImages()
                     }
                 }
@@ -159,7 +119,7 @@ pipeline {
         stage('Tag images') {
             steps {
                 script {
-                    dir('kogito-images') {
+                    dir(getRepoName()) {
                         tagImages()
                     }
                 }
@@ -173,7 +133,7 @@ pipeline {
                     } else if (getNewImageRegistryCredentials() != '') {
                         loginContainerRegistry(getNewImageRegistry(), getNewImageRegistryCredentials())
                     }
-                    dir('kogito-images') {
+                    dir(getRepoName()) {
                         pushImages()
 
                         if (isQuayRegistry(getNewImageRegistry()) && getNewImageQuayTokenCredentials()) {
@@ -189,9 +149,9 @@ pipeline {
             }
             steps {
                 script {
-                    dir('kogito-images') {
+                    dir(getRepoName()) {
                         // Merge PR
-                        String prLink = getDeployProperty('kogito-images.pr.link')
+                        String prLink = getDeployProperty("${getRepoName()}.pr.link")
                         if (prLink != '') {
                             githubscm.mergePR(prLink, getGitAuthorCredsID())
                             githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
@@ -200,7 +160,7 @@ pipeline {
                         if (getGitTag() != '') {
                             def releaseName = "Kogito Images Version ${getProjectVersion()}"
                             def description = params.RELEASE_NOTES != '' ? params.RELEASE_NOTES : "We are glad to announce that the Kogito ${getProjectVersion()} release is now available!"
-                            withCredentials([string(credentialsId: params.GITHUB_TOKEN_CREDS_ID, variable: 'GITHUB_TOKEN')]) {
+                            withCredentials([string(credentialsId: env.GITHUB_TOKEN_CREDS_ID, variable: 'GITHUB_TOKEN')]) {
                                 sh """
                                     export GITHUB_USER=${getGitAuthor()}
                                     github-release release --tag ${getGitTag()} --target '${getBuildBranch()}' --name '${releaseName}' --description '${description}' --pre-release
@@ -220,7 +180,7 @@ pipeline {
                 script {
                     String prLink = ''
                     String nextVersion = getNextVersion()
-                    dir('kogito-images-snapshot') { // Use different folder from `Update PR with released Maven artifacts` to avoid conflicts
+                    dir('bot') { // Use different folder from `Update PR with released Maven artifacts` to avoid conflicts
                         // Prepare PR
                         checkoutRepo()
                         githubscm.forkRepo(getBotAuthorCredsID())
@@ -239,7 +199,7 @@ pipeline {
                         githubscm.pushObject('origin', getSnapshotBranch(), getBotAuthorCredsID())
                         prLink = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
                     }
-                    dir('kogito-images') {
+                    dir(getRepoName()) {
                         if (prLink != '') {
                             githubscm.mergePR(prLink, getGitAuthorCredsID())
                             githubscm.pushObject('origin', getBuildBranch(), getGitAuthorCredsID())
@@ -262,7 +222,7 @@ void installGitHubReleaseCLI() {
 
 void checkoutRepo() {
     deleteDir()
-    checkout(githubscm.resolveRepository('kogito-images', getGitAuthor(), getBuildBranch(), false))
+    checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
     // need to manually checkout branch since on a detached branch after checkout command
     sh "git checkout ${getBuildBranch()}"
 }
@@ -399,7 +359,11 @@ String getParamOrDeployProperty(String paramKey, String deployPropertyKey) {
 ////////////////////////////////////////////////////////////////////////
 
 boolean isRelease() {
-    return params.RELEASE || (getDeployProperty('release') == 'true')
+    return env.RELEASE.toBoolean()
+}
+
+String getRepoName() {
+    return env.REPO_NAME
 }
 
 String getProjectVersion() {
@@ -416,27 +380,27 @@ String getGitTag() {
 }
 
 String getBuildBranch() {
-    return getParamOrDeployProperty('BUILD_BRANCH_NAME', 'git.branch')
+    return params.BUILD_BRANCH_NAME
 }
 
 String getPRSourceBranch() {
-    return getDeployProperty('kogito-images.pr.source.ref')
+    return getDeployProperty("${getRepoName()}.pr.source.ref")
 }
 
 String getGitAuthor() {
-    return getParamOrDeployProperty('GIT_AUTHOR', 'git.author')
+    return env.GIT_AUTHOR
 }
 
 String getGitAuthorCredsID() {
-    return params.AUTHOR_CREDS_ID
+    return env.AUTHOR_CREDS_ID
 }
 
 String getBotAuthorCredsID() {
-    return params.BOT_CREDENTIALS_ID
+    return env.BOT_CREDENTIALS_ID
 }
 
 String getMavenArtifactRepository() {
-    return params.MAVEN_ARTIFACT_REPOSITORY
+    return env.MAVEN_ARTIFACT_REPOSITORY ?: ''
 }
 
 String getNextVersion() {
@@ -461,7 +425,7 @@ boolean isQuayRegistry(String registry) {
 ////////////////////////////////////////////////////////////////////////
 
 String getOldImagePrefix() {
-    return 'kogito-images.image'
+    return "${getRepoName()}.image"
 }
 
 boolean isOldImageInOpenshiftRegistry() {

--- a/modules/kogito-maven/3.6.x/added/configure-maven.sh
+++ b/modules/kogito-maven/3.6.x/added/configure-maven.sh
@@ -97,7 +97,7 @@ function configure_maven_download_output() {
 
 function ignore_maven_self_signed_certificates() {
     if [ "${MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE}" == "true" ]; then
-        export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true"
+        export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -Denforcer.skip -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true"
     fi
 }
 

--- a/modules/kogito-maven/tests/bats/maven-settings.bats
+++ b/modules/kogito-maven/tests/bats/maven-settings.bats
@@ -168,7 +168,7 @@ function _generate_random_id() {
     prepareEnv
     MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE="true"
     ignore_maven_self_signed_certificates
-    expected=" -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true"
+    expected=" -Denforcer.skip -Dmaven.wagon.http.ssl.insecure=true -Dmaven.wagon.http.ssl.allowall=true"
     result="${MAVEN_ARGS_APPEND}"
     echo "expected=${expected}"
     echo "result=${result}"

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -307,6 +307,15 @@ def update_maven_repo_in_clone_repo(repo_url, replaceJbossRepository):
         replacement = 'export MAVEN_REPO_URL="{}"'.format(repo_url)
     update_in_file(CLONE_REPO_SCRIPT, pattern, replacement)
 
+def ignore_maven_self_signed_certificate_in_clone_repo():
+    """
+    Sets the environment variable to ignore the self-signed certificates in maven
+    """
+    print("Setting MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE env in clone repo")
+    pattern = re.compile(r'(# MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE=.*)')
+    replacement = "MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE=true"
+    update_in_file(CLONE_REPO_SCRIPT, pattern, replacement)
+
 
 def update_in_file(file, pattern, replacement):
     """

--- a/scripts/update-tests.py
+++ b/scripts/update-tests.py
@@ -37,3 +37,4 @@ if __name__ == "__main__":
     
     if args.ignore_self_signed_cert:
         common.ignore_maven_self_signed_certificate_in_behave_tests()
+        common.ignore_maven_self_signed_certificate_in_clone_repo()

--- a/tests/test-apps/clone-repo.sh
+++ b/tests/test-apps/clone-repo.sh
@@ -5,13 +5,15 @@
 SCRIPT_DIR=`pwd`
 MVN_MODULE="${SCRIPT_DIR}/../../modules/kogito-maven/3.6.x"
 CONTAINER_ENGINE="docker"
+MAVEN_OPTIONS="-DskipTests -U"
 MAVEN_QUARKUS_NATIVE_CONTAINER_BUILD_ARGS="-Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=${CONTAINER_ENGINE}"
+# MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE=true
 
 # exit when any command fails
 set -e
-#Setup maven configuration only on CI
+# Setup maven configuration only on CI
 if [ "${CI}" ]; then
-# setup maven env
+    # setup maven env
     export JBOSS_MAVEN_REPO_URL="https://repository.jboss.org/nexus/content/groups/public/"
     # export MAVEN_REPO_URL=
     cp "${MVN_MODULE}"/maven/settings.xml "${HOME}"/.m2/settings.xml
@@ -19,6 +21,10 @@ if [ "${CI}" ]; then
     configure
 
     cat "${HOME}"/.m2/settings.xml
+fi
+
+if [ "${MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE}" = "true" ]; then
+    MAVEN_OPTIONS="${MAVEN_OPTIONS} -Denforcer.skip"
 fi
 
 # Clone examples
@@ -33,9 +39,9 @@ git checkout master
 cp -rv  /tmp/kogito-examples/rules-quarkus-helloworld/ /tmp/kogito-examples/rules-quarkus-helloworld-native/
 
 # generating the app binaries to test the binary build
-mvn -f rules-quarkus-helloworld clean package -DskipTests -U
-mvn -f process-springboot-example clean package -DskipTests -U
-mvn -f rules-quarkus-helloworld-native -Pnative clean package -DskipTests -U ${MAVEN_QUARKUS_NATIVE_CONTAINER_BUILD_ARGS}
+mvn -f rules-quarkus-helloworld clean package ${MAVEN_OPTIONS}
+mvn -f process-springboot-example clean package ${MAVEN_OPTIONS}
+mvn -f rules-quarkus-helloworld-native -Pnative clean package ${MAVEN_OPTIONS} ${MAVEN_QUARKUS_NATIVE_CONTAINER_BUILD_ARGS}
 
 # preparing directory to run kogito maven archetypes tests
 mkdir -pv /tmp/kogito-examples/dmn-example


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3034
https://issues.redhat.com/browse/BXMSPROD-1094

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/92
- https://github.com/kiegroup/kogito-runtimes/pull/940
- https://github.com/kiegroup/kogito-apps/pull/581
- https://github.com/kiegroup/optaplanner/pull/1085
- https://github.com/kiegroup/kogito-examples/pull/500
- https://github.com/kiegroup/kogito-images/pull/307
- https://github.com/kiegroup/kogito-cloud-operator/pull/710

**Setup DSL scripts for the different Kogito jobs.**

- Allow easy setup of jobs for own purpose (with different configuration for example)
- Moved parameters as environment
  - That allows exact same configuration information for all the jobs, without having to 
  - For testing, taking the getting the seed job and generating for its own GH author is easy
- Separate folders for nightly and release
  - And still keep branching parts
  - Means deploy/promote jobs are copied in each of them
  - Gives a better history of running jobs without losing release part for example
  - Created also a `pullrequest/kogito-runtimes.bdd` folder for deploy jobs used in that specific PR check

More information on https://github.com/kiegroup/kogito-pipelines/pull/92

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster