### PR TITLE
[KOGITO-1031] Add flag to ignore self-signed SSL certificate

### DIFF
--- a/Jenkinsfile.deploy
+++ b/Jenkinsfile.deploy
@@ -101,6 +101,9 @@ pipeline {
             }
         }
         stage('Prepare for PR') {
+            when {
+                expression { return isRelease() || isCreateChangesPR() }
+            }
             steps {
                 script {
                     githubscm.forkRepo(getBotAuthorCredsID())
@@ -133,7 +136,7 @@ pipeline {
                     // Update artifacts
                     updateArtifactCmd = 'python3 scripts/update-maven-artifacts.py'
                     if (getMavenArtifactRepository() != '') {
-                        updateArtifactCmd += " --repo-url ${getMavenArtifactRepository()}"
+                        updateArtifactCmd += " --repo-url ${getMavenArtifactRepository()} --ignore-self-signed-cert"
                     }
                     sh updateArtifactCmd
 

--- a/scripts/update-maven-artifacts.py
+++ b/scripts/update-maven-artifacts.py
@@ -50,7 +50,7 @@ def getMetadataRoot(service):
     :return: root object
     '''
     metadataURL=service["repo_url"]+"maven-metadata.xml"
-    mavenMetadata=requests.get(metadataURL)
+    mavenMetadata=requests.get(metadataURL, verify=service["ignore_self_signed_cert"])
     with open('maven-metadata.xml', 'wb') as f:
         f.write(mavenMetadata.content)
     tree = ET.parse('maven-metadata.xml')
@@ -121,6 +121,7 @@ def update_artifacts(service,modulePath):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Update Maven information in repo from the given maven repository')
     parser.add_argument('--repo-url', dest='repo_url', default=DEFAULT_REPO_URL, help='Defines the url of the repository to extract the artifacts from, defaults to {}'.format(DEFAULT_REPO_URL))
+    parser.add_argument('--ignore-self-signed-cert', action='store_false', help='If set, will relax the SSL for user-generated self-signed certificates')
     args = parser.parse_args()
     
     artifactsVersion = common.retrieve_artifacts_version()
@@ -131,7 +132,8 @@ if __name__ == "__main__":
         service = {
             "repo_url" : args.repo_url + "{}/{}/{}/".format(KOGITO_ARTIFACT_PATH, serviceName, artifactsVersion),
             "name" : serviceName,
-            "version" : artifactsVersion
+            "version" : artifactsVersion,
+            "ignore_self_signed_cert": args.ignore_self_signed_cert
         }
         moduleYamlFile = "modules/{}/module.yaml".format(modulePath)
         


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-1031

This is an accompanying PR to [the one opened in kogito-pipelines](https://github.com/kiegroup/kogito-pipelines/pull/46). 

## Testing
I was able to [run the `update-maven-artifacts.py` script](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/kogito/job/kogito-images-deploy-1031/14/execution/node/66/log/) with the Maven test repository with the self-signed certificate, despite the given warnings (it would previously fail), using the code from this PR.

## Requirements
Many thanks for submitting your Pull Request :heart:! 

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
