### PR TITLE
[1.5.x][KOGITO-5056] - rhpam-kogito-builder-rhel8 image is using a wrong label

### DIFF
--- a/rhpam-kogito-builder-rhel8-overrides.yaml
+++ b/rhpam-kogito-builder-rhel8-overrides.yaml
@@ -7,7 +7,7 @@ description: "RHPAM Platform for building Kogito based on Quarkus or SpringBoot"
 
 labels:
   - name: "com.redhat.component"
-    value: "rhpam-7-kogito-runtime-jvm-rhel8-container"
+    value: "rhpam-7-kogito-builder-rhel8-container"
   - name: "io.k8s.description"
     value: "RHPAM Platform for building Kogito based on Quarkus or Spring Boot"
   - name: "io.k8s.display-name"

--- a/tests/features/rhpam-kogito-builder-jvm.feature
+++ b/tests/features/rhpam-kogito-builder-jvm.feature
@@ -11,4 +11,4 @@ Feature: rhpam-kogito-builder-rhel8 feature.
     And the image should contain label io.k8s.display-name with value Red Hat build of Kogito builder based on Quarkus or SpringBoot
     And the image should contain label io.openshift.tags with value rhpam-kogito,builder,kogito,quarkus,springboot
     And the image should contain label io.openshift.s2i.assemble-input-files with value /home/kogito/bin
-    And the image should contain label com.redhat.component with value rhpam-7-kogito-runtime-jvm-rhel8-container
+    And the image should contain label com.redhat.component with value rhpam-7-kogito-builder-rhel8-container


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 
See: https://issues.redhat.com/browse/KOGITO-5056

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster