### PR TITLE
Update `openshift-template-validator` branch name to `main`

### DIFF
--- a/.github/workflows/kogito-images-pr-check.yml
+++ b/.github/workflows/kogito-images-pr-check.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download openshift-validator-tool
         run: |
-          wget https://github.com/jboss-container-images/jboss-kie-modules/raw/master/tools/openshift-template-validator/openshift-template-validator-linux-amd64
+          wget https://github.com/jboss-container-images/jboss-kie-modules/raw/main/tools/openshift-template-validator/openshift-template-validator-linux-amd64
       - name: Add execution permission to openshift-validator-tool
         run: |
           chmod +x openshift-template-validator-linux-amd64


### PR DESCRIPTION
This should solve the GHAction since migration from `master` to `main` branch on `jboss-kie-modules`

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster