### PR TITLE
[KOGITO-5526] - Native Runtime img missing module

### DIFF
--- a/modules/kogito-runtime-native/added/kogito-app-launch.sh
+++ b/modules/kogito-runtime-native/added/kogito-app-launch.sh
@@ -15,17 +15,12 @@ fi
 # Configuration scripts
 # Any configuration script that needs to run on image startup must be added here.
 CONFIGURE_SCRIPTS=(
-    "${KOGITO_HOME}"/launch/configure-custom-truststore.sh
+
 )
 source "${KOGITO_HOME}"/launch/configure.sh
 #############################################
 
-if [ -z "${CUSTOM_TRUSTSTORE_ARGS}" ]; then
-    CUSTOM_TRUSTSTORE_ARGS="-Djavax.net.ssl.trustStore=${KOGITO_HOME}/cacerts"
-fi
-
 # shellcheck disable=SC2086
 exec "${KOGITO_HOME}"/bin/*-runner ${JAVA_OPTIONS} ${KOGITO_QUARKUS_NATIVE_PROPS} \
     -Dquarkus.http.host=0.0.0.0 -Djava.library.path="${KOGITO_HOME}"/ssl-libs \
-    -Dquarkus.http.port=8080 \
-    ${CUSTOM_TRUSTSTORE_ARGS} 
+    -Dquarkus.http.port=8080


### PR DESCRIPTION
Kogito runtime native image is logging `/home/kogito/launch/configure.sh: line 68: /home/kogito/launch/configure-custom-truststore.sh: No such file or directory`

See: https://issues.redhat.com/browse/KOGITO-5526
cherry-picks: https://github.com/kiegroup/kogito-images/pull/607

Signed-off-by: spolti <fspolti@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster