### PR TITLE
[KOGITO-5623] Fix Behave tests for SW builder

### DIFF
--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -163,7 +163,7 @@ function build_kogito_app() {
 
             log_info "--> Quarkus version is '$quarkus_version'"
 
-            $MAVEN_HOME/bin/mvn ${MAVEN_ARGS_APPEND} -s "${KOGITO_HOME}"/.m2/settings.xml io.quarkus:quarkus-maven-plugin:$quarkus_version:add-extension -Dextensions="org.kie.kogito:kogito-quarkus-serverless-workflow"
+            $MAVEN_HOME/bin/mvn ${MAVEN_ARGS_APPEND} -s "${KOGITO_HOME}"/.m2/settings.xml io.quarkus:quarkus-maven-plugin:$quarkus_version:add-extension -Dextensions="org.kie.kogito:kogito-quarkus-serverless-workflow" -DquarkusRegistryClient=false
         fi
 
         $MAVEN_HOME/bin/mvn clean package ${MAVEN_ARGS_APPEND} ${KOGITO_OPTS} ${nativeBuild} -s "${KOGITO_HOME}"/.m2/settings.xml \

--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -163,6 +163,7 @@ function build_kogito_app() {
 
             log_info "--> Quarkus version is '$quarkus_version'"
 
+            # `-DquarkusRegistryClient=false` is added until https://github.com/quarkusio/registry.quarkus.io/issues/22 is solved because of maven mirror
             $MAVEN_HOME/bin/mvn ${MAVEN_ARGS_APPEND} -s "${KOGITO_HOME}"/.m2/settings.xml io.quarkus:quarkus-maven-plugin:$quarkus_version:add-extension -Dextensions="org.kie.kogito:kogito-quarkus-serverless-workflow" -DquarkusRegistryClient=false
         fi
 

--- a/tests/features/kogito-builder.feature
+++ b/tests/features/kogito-builder.feature
@@ -101,7 +101,7 @@ Feature: kogito-builder image tests
       | expected_status_code  | 200                           |
       | request_method        | POST                          |
       | content_type          | application/cloudevents+json  |
-      | request_body          | {"specversion": "1.0", "source": "behave", "type": "orderEvent", "id": "12345", "data": {"id":"f0643c68-609c-48aa-a820-5df423fa4fe0","country":"Brazil","total":10000,"description":"iPhone 12"}}|
+      | request_body          | {"specversion": "1.0", "datacontenttype": "application/json", "source": "behave", "type": "orderEvent", "id": "12345", "data": {"id":"f0643c68-609c-48aa-a820-5df423fa4fe0","country":"Brazil","total":10000,"description":"iPhone 12"}}|
 
 #### SpringBoot Scenarios
 


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See https://issues.redhat.com/browse/KOGITO-5623

This PR fixes the error in the SW behave test. We were missing the `datacontenttype` attribute in the CE payload.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster