### PR TITLE
[KOGITO-5698] Restored quarkus registry client

### DIFF
--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -163,8 +163,7 @@ function build_kogito_app() {
 
             log_info "--> Quarkus version is '$quarkus_version'"
 
-            # `-DquarkusRegistryClient=false` is added until https://github.com/quarkusio/registry.quarkus.io/issues/22 is solved because of maven mirror
-            $MAVEN_HOME/bin/mvn ${MAVEN_ARGS_APPEND} -s "${KOGITO_HOME}"/.m2/settings.xml io.quarkus:quarkus-maven-plugin:$quarkus_version:add-extension -Dextensions="org.kie.kogito:kogito-quarkus-serverless-workflow" -DquarkusRegistryClient=false
+            $MAVEN_HOME/bin/mvn ${MAVEN_ARGS_APPEND} -s "${KOGITO_HOME}"/.m2/settings.xml io.quarkus:quarkus-maven-plugin:$quarkus_version:add-extension -Dextensions="org.kie.kogito:kogito-quarkus-serverless-workflow"
         fi
 
         $MAVEN_HOME/bin/mvn clean package ${MAVEN_ARGS_APPEND} ${KOGITO_OPTS} ${nativeBuild} -s "${KOGITO_HOME}"/.m2/settings.xml \


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5698

Follow-up on workaround from https://github.com/kiegroup/kogito-images/pull/631

Nexus mirror solved in https://github.com/quarkusio/registry.quarkus.io/pull/25

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster