### PR TITLE
[KOGITO-6333] Enforce Jackson RestEasy in auto-generated projects

### DIFF
--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -113,7 +113,7 @@ function build_kogito_app() {
                     -DprojectGroupId=$PROJECT_GROUP_ID \
                     -DprojectArtifactId=$PROJECT_ARTIFACT_ID \
                     -DprojectVersion=$PROJECT_VERSION \
-                    -Dextensions="kogito,quarkus-smallrye-health,quarkus-smallrye-openapi"
+                    -Dextensions="kogito,quarkus-smallrye-health,quarkus-smallrye-openapi,quarkus-resteasy,quarkus-resteasy-jackson"
 
         elif [ "${RUNTIME_TYPE}" == "${SPRINGBOOT_RUNTIME_TYPE}" ]; then
             log_info "----> Using Spring Boot to bootstrap the application."


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See: https://issues.redhat.com/browse/KOGITO-6333

Instead of adding just for SW, let's make sure that every generated project has the dependency as well to avoid failing in the integration tests since now the rest generation is optional.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster