### PR TITLE
[1.11.x] Allow maven mirror for archetype tests

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -306,7 +306,7 @@ def update_maven_mirror_url_in_archetype_behave_tests(repo_url):
     """
     print("Set maven repo {} in archetype behave tests".format(repo_url))
     pattern = re.compile('(Kogito Maven archetype.*\r?\n\s*Given.*\r?\n\s*)\|\s*variable[\s]*\|[\s]*value[\s]*\|')
-    replacement = "\g<1>| variable | value |\n      | {} | {} |".format("MAVEN_MIRROR_URL", repo_url)
+    replacement = "\g<1>| variable | value |\n      | {} | {} |\n      | DEBUG | true |".format("MAVEN_MIRROR_URL", repo_url)
     update_in_behave_tests(pattern, replacement)
 
 def ignore_maven_self_signed_certificate_in_behave_tests():

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -299,14 +299,14 @@ def update_maven_repo_in_behave_tests(repo_url, replaceJbossRepository):
                                                                                                            repo_url)
     update_in_behave_tests(pattern, replacement)
 
-def update_maven_mirror_url_in_archetype_behave_tests(repo_url):
+def update_maven_mirror_url_in_quarkus_plugin_behave_tests(repo_url):
     """
     Update maven repository into behave tests
     :param repo_url: Maven repository url
     """
-    print("Set maven repo {} in archetype behave tests".format(repo_url))
-    pattern = re.compile('(Kogito Maven archetype.*\r?\n\s*Given.*\r?\n\s*)\|\s*variable[\s]*\|[\s]*value[\s]*\|')
-    replacement = "\g<1>| variable | value |\n      | {} | {} |\n      | DEBUG | true |".format("MAVEN_MIRROR_URL", repo_url)
+    print("Set maven repo {} in quarkus plugin behave tests".format(repo_url))
+    pattern = re.compile('(Kogito Maven archetype.*(?<!springboot)\r?\n\s*Given.*\r?\n\s*)\|\s*variable[\s]*\|[\s]*value[\s]*\|')
+    replacement = "\g<1>| variable | value |\n      | {} | {} |\n      | MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE | true |\n      | DEBUG | true |".format("MAVEN_MIRROR_URL", repo_url)
     update_in_behave_tests(pattern, replacement)
 
 def ignore_maven_self_signed_certificate_in_behave_tests():
@@ -317,15 +317,6 @@ def ignore_maven_self_signed_certificate_in_behave_tests():
     pattern = re.compile('\|\s*variable[\s]*\|[\s]*value[\s]*\|')
     replacement = "| variable | value |\n      | MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE | true |"
     update_in_behave_tests(pattern, replacement)
-
-def ignore_maven_self_signed_certificate_in_archetype_behave_tests():
-    """
-    Sets the environment variable to ignore the self-signed certificates in maven
-    """
-    print("Setting MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE env in behave tests")
-    pattern = re.compile('(Kogito Maven archetype.*\r?\n\s*Given.*\r?\n\s*)\|\s*variable[\s]*\|[\s]*value[\s]*\|')
-    replacement = "\g<1>| variable | value |\n      | MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE | true |"
-    update_in_behave_tests(pattern, replacement)   
 
 
 def update_in_behave_tests(pattern, replacement):

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -299,6 +299,15 @@ def update_maven_repo_in_behave_tests(repo_url, replaceJbossRepository):
                                                                                                            repo_url)
     update_in_behave_tests(pattern, replacement)
 
+def update_maven_mirror_url_in_archetype_behave_tests(repo_url):
+    """
+    Update maven repository into behave tests
+    :param repo_url: Maven repository url
+    """
+    print("Set maven repo {} in archetype behave tests".format(repo_url))
+    pattern = re.compile('(Kogito Maven archetype.*\r?\n\s*Given.*\r?\n\s*)\|\s*variable[\s]*\|[\s]*value[\s]*\|')
+    replacement = "\g<1>| variable | value |\n      | {} | {} |".format("MAVEN_MIRROR_URL", repo_url)
+    update_in_behave_tests(pattern, replacement)
 
 def ignore_maven_self_signed_certificate_in_behave_tests():
     """
@@ -308,6 +317,15 @@ def ignore_maven_self_signed_certificate_in_behave_tests():
     pattern = re.compile('\|\s*variable[\s]*\|[\s]*value[\s]*\|')
     replacement = "| variable | value |\n      | MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE | true |"
     update_in_behave_tests(pattern, replacement)
+
+def ignore_maven_self_signed_certificate_in_archetype_behave_tests():
+    """
+    Sets the environment variable to ignore the self-signed certificates in maven
+    """
+    print("Setting MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE env in behave tests")
+    pattern = re.compile('(Kogito Maven archetype.*\r?\n\s*Given.*\r?\n\s*)\|\s*variable[\s]*\|[\s]*value[\s]*\|')
+    replacement = "\g<1>| variable | value |\n      | MAVEN_IGNORE_SELF_SIGNED_CERTIFICATE | true |"
+    update_in_behave_tests(pattern, replacement)   
 
 
 def update_in_behave_tests(pattern, replacement):

--- a/scripts/update-tests.py
+++ b/scripts/update-tests.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
     parser.add_argument('--ignore-self-signed-cert', dest='ignore_self_signed_cert', default=False, action='store_true', help='If set to true will relax the SSL for user-generated self-signed certificates')
     parser.add_argument('--runtime-image-jvm', dest='runtime_image_jvm', help='To update the runtime jvm image name in behave tests\'s steps')
     parser.add_argument('--runtime-image-native', dest='runtime_image_native', help='To update the runtime native image name in behave tests\'s steps')
+    parser.add_argument('--archetype-maven-mirror-url', dest='archetype_maven_mirror_url', help='Maven mirror URL to be used for archetype generation')
     args = parser.parse_args()
 
     if args.repo_url:
@@ -46,3 +47,7 @@ if __name__ == "__main__":
     
     if args.runtime_image_native:
         common.update_runtime_image_in_behave_tests(args.runtime_image_native, 'native')
+    
+    if args.archetype_maven_mirror_url:
+        common.update_maven_mirror_url_in_archetype_behave_tests(args.archetype_maven_mirror_url)
+        common.ignore_maven_self_signed_certificate_in_archetype_behave_tests()

--- a/scripts/update-tests.py
+++ b/scripts/update-tests.py
@@ -49,5 +49,4 @@ if __name__ == "__main__":
         common.update_runtime_image_in_behave_tests(args.runtime_image_native, 'native')
     
     if args.archetype_maven_mirror_url:
-        common.update_maven_mirror_url_in_archetype_behave_tests(args.archetype_maven_mirror_url)
-        common.ignore_maven_self_signed_certificate_in_archetype_behave_tests()
+        common.update_maven_mirror_url_in_quarkus_plugin_behave_tests(args.archetype_maven_mirror_url)


### PR DESCRIPTION
This is done to be able to use a specific repository for the Quarkus platform.
Useful when you need a specific build of it.

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster