### PR TITLE
[1.11.x] [RHPAM-4143] Exclude memory-limit.sh for non-native image build

### DIFF
--- a/modules/kogito-builder/s2i/bin/assemble
+++ b/modules/kogito-builder/s2i/bin/assemble
@@ -20,11 +20,17 @@ log_info "----> RUNTIME_TYPE has been set to $runtime_type"
 # Configure GraalVM memory limits
 
 case ${runtime_type} in 
-    "quarkus") 
-              CONFIGURE_SCRIPTS=(
+    "quarkus")
+	if [ "${NATIVE^^}" == "TRUE" ]; then
+	      CONFIGURE_SCRIPTS=(
                 "${KOGITO_HOME}"/launch/configure-maven.sh
                 "${KOGITO_HOME}"/launch/memory-limit.sh
               )
+	else
+	      CONFIGURE_SCRIPTS=(
+                "${KOGITO_HOME}"/launch/configure-maven.sh
+              )
+	fi
     ;;
     "springboot") 
               CONFIGURE_SCRIPTS=(


### PR DESCRIPTION
For Kogito java images, memory-limit.sh script is there to limit memory usage for Graal VM native builds, so it should be executed only for native builds and excluded for non-native builds.

And this is directly impacting Kogito java J9 images for IBM z/p platforms since GraalVM natives are not supported there. Without the exclusion, j9 images won't start properly.

Jira ticket: https://issues.redhat.com/browse/RHPAM-4143
cc @radtriste @AntStephenson

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
  [] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change