### PR TITLE
[KOGITO-6215] - Improve logs on kogito-builder image while trying to get project version

### DIFF
--- a/modules/kogito-s2i-core/added/s2i-core
+++ b/modules/kogito-s2i-core/added/s2i-core
@@ -273,7 +273,6 @@ function get_quarkus_version() {
     if [ "${QUARKUS_VERSION}x" = "x" ]; then
         log_info "----> Trying to retrieve Quarkus version from org.kie.kogito:kogito-build-parent:${KOGITO_VERSION}"
         ver=$($MAVEN_HOME/bin/mvn ${MAVEN_ARGS_APPEND} -s "${KOGITO_HOME}"/.m2/settings.xml help:evaluate -q \
-            -Dartifact=org.kie.kogito:kogito-build-parent:"${KOGITO_VERSION}" \
             -Dexpression=version.io.quarkus \
             -DforceStdout)
 


### PR DESCRIPTION
[KOGITO-6215] - Improve logs on kogito-builder image while trying to get project version
Removed -Dartifact=... parameter so artifact isn't searched against Maven Central Repository
https://issues.redhat.com/browse/KOGITO-6215

Signed-off-by: Achyut Madhusudan <amadhusu@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [X] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [X] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Your feature/bug fix has a testcase that verifies it
- [X] You've tested the new feature/bug fix in an actual OpenShift cluster
  [X] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change