### PR TITLE
[1.13.x] Prepare branch for productization

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -4,8 +4,10 @@ def changeAuthor = env.ghprbAuthorRepoGitUrl ? util.getGroup(env.ghprbAuthorRepo
 def changeBranch = env.ghprbSourceBranch ?: CHANGE_BRANCH
 def changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
 
-pipeline{
-    agent { label 'kogito-image-slave && !master'}
+BUILD_FAILED_IMAGES = []
+
+pipeline {
+    agent { label 'kogito-image-slave && !master' }
     tools {
         jdk 'kie-jdk11'
     }
@@ -15,28 +17,28 @@ pipeline{
     environment {
         CI = true
     }
-    stages{
-        stage('Initialization'){
-            steps{
-                script{
+    stages {
+        stage('Initialization') {
+            steps {
+                script {
                     clean()
-                    
+
                     // Set the mirror url only if exist
                     if (env.MAVEN_MIRROR_REPOSITORY != null
-                            && env.MAVEN_MIRROR_REPOSITORY != ''){
+                            && env.MAVEN_MIRROR_REPOSITORY != '') {
                         env.MAVEN_MIRROR_URL = env.MAVEN_MIRROR_REPOSITORY
-                    }
+                            }
 
                     githubscm.checkoutIfExists('kogito-images', changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
 
                     //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
-                    if(env.MAVEN_MIRROR_URL != ''){
+                    if (env.MAVEN_MIRROR_URL != '') {
                         sh 'python3 scripts/update-tests.py --ignore-self-signed-cert'
                     }
                 }
             }
         }
-        stage('Validate CeKit Image and Modules descriptors'){
+        stage('Validate CeKit Image and Modules descriptors') {
             steps {
                 script {
                     sh '''
@@ -46,35 +48,76 @@ pipeline{
                     '''
                     sh './cekit-image-validator-runner modules/'
                     sh './cekit-image-validator-runner image.yaml'
-                    getImages().each{ image -> sh "./cekit-image-validator-runner ${image}-overrides.yaml" }   
+                    getImages().each { image -> sh "./cekit-image-validator-runner ${image}-overrides.yaml" }
                 }
             }
         }
-        stage('Prepare offline kogito-examples'){
-            steps{
-                sh "make clone-repos"
+        stage('Prepare offline kogito-examples') {
+            steps {
+                sh 'make clone-repos'
             }
         }
-        stage('Build Images') {
-            steps{
-                script {
-                    getImages().each{ image -> initWorkspace(image) }
-                    launchParallelForEachImage("Build", {img -> buildImage(img)})
-                }
-            }
-        }
-        stage('Test Images') {
+        stage('Build & Test Images') {
             steps {
                 script {
-                    launchParallelForEachImage("Test", {img -> testImage(img)})
+                    parallelStages = [:]
+                    getImages().each { image ->
+                        initWorkspace(image)
+                        String workspacePath = getWorkspacePath(image)
+                        parallelStages["Build&Test ${image}"] = {
+                            stage("Build ${image}") {
+                                try {
+                                    dir(workspacePath) {
+                                        buildImage(image)
+                                    }
+                                } catch (err) {
+                                    registerBuildFailedImage(image)
+                                    util.archiveConsoleLog(image)
+                                    throw err
+                                }
+                            }
+                            stage("Test ${image}") {
+                                dir(workspacePath) {
+                                    try {
+                                        testImage(image)
+                                    } catch (err) {
+                                        echo "Testing error(s) for image ${image}"
+                                    } finally {
+                                        junit testResults: 'target/test/results/*.xml', allowEmptyResults: true
+                                        archiveArtifacts artifacts: 'target/test/results/*.xml', allowEmptyArchive: true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    parallel parallelStages
+                }
+            }
+            post {
+                always {
+                    script {
+                        cleanWorkspaces()
+                    }
                 }
             }
         }
     }
-    post{
-        always{
-            script{
+    post {
+        always {
+            script {
                 clean()
+            }
+        }
+        unsuccessful {
+            script {
+                def additionalInfo = ''
+                if (getBuildFailedImages()){
+                    additionalInfo += 'Build failures on those images:\n'
+                    getBuildFailedImages().each {
+                        additionalInfo += "- ${it}\n"
+                    }
+                }
+                pullrequest.postComment(util.getMarkdownTestSummary('PR', additionalInfo, "${BUILD_URL}", 'GITHUB'))
             }
         }
     }
@@ -88,16 +131,16 @@ void clean() {
     sh "rm -rf \$HOME/.cekit/cache"
 }
 
-void cleanImages(){
+void cleanImages() {
     sh "docker rm -f \$(docker ps -a -q) || date"
     sh "docker rmi -f \$(docker images -q) || date"
 }
 
 void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
     parallelStages = [:]
-    getImages().each{ image -> 
+    getImages().each { image ->
         parallelStages["${stageNamePrefix} ${image}"] = {
-            dir(getWorkspacePath(image)){
+            dir(getWorkspacePath(image)) {
                 executeOnImage(image)
             }
         }
@@ -105,35 +148,41 @@ void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
     parallel parallelStages
 }
 
-void buildImage(image) {
-    sh "make build-image image_name=${image} ignore_test=true cekit_option='--work-dir .'"
+void buildImage(String imageName) {
+    sh "make build-image image_name=${imageName} ignore_test=true cekit_option='--work-dir .'"
 }
 
-void testImage(image) {
-    try {
-        sh "make build-image image_name=${image} ignore_build=true cekit_option='--work-dir .'"
-    } finally {
-        junit testResults: 'target/test/results/*.xml', allowEmptyResults: true
+void testImage(String imageName) {
+    sh "make build-image image_name=${imageName} ignore_build=true cekit_option='--work-dir .'"
+}
+
+void registerBuildFailedImage(String imageName) {
+    lock("${BUILD_URL} build failed") {
+        BUILD_FAILED_IMAGES.add(imageName)
     }
 }
 
-void initWorkspace(String image){
+List getBuildFailedImages() {
+    return BUILD_FAILED_IMAGES
+}
+
+void initWorkspace(String image) {
     sh "mkdir -p ${getWorkspacePath(image)}"
     sh "rsync -av --progress . ${getWorkspacePath(image)} --exclude workspaces"
 }
 
-void cleanWorkspaces(){
+void cleanWorkspaces() {
     sh "rm -rf ${getWorkspacesPath()}"
 }
 
-String getWorkspacesPath(){
+String getWorkspacesPath() {
     return "${WORKSPACE}/workspaces"
 }
 
-String getWorkspacePath(String image){
+String getWorkspacePath(String image) {
     return "${getWorkspacesPath()}/${image}"
 }
 
-String[] getImages(){
+String[] getImages() {
     return sh(script: "make list | tr '\\n' ','", returnStdout: true).trim().split(',')
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -5,7 +5,8 @@ deployProperties = [ : ]
 commitDone = false
 
 BUILT_IMAGES = []
-FAILED_IMAGES = []
+BUILD_FAILED_IMAGES = []
+TEST_FAILED_IMAGES = []
 
 pipeline {
     agent {
@@ -184,33 +185,41 @@ pipeline {
                 }
             }
         }
-        stage('Build Images') {
+        stage('Build & Test Images') {
             steps {
                 script {
-                    // Init workspaces before build
-                    getImages().each { image -> initWorkspace(image) }
-                    // Build images
-                    launchParallelForEachImage('Build', { img -> buildImage(img) })
-                }
-            }
-            post {
-                always {
-                    script {
-                        cleanWorkspaces()
+                    parallelStages = [:]
+                    getImages().each { image -> 
+                        initWorkspace(image)
+                        String workspacePath = getWorkspacePath(image)
+                        parallelStages["Build&Test ${image}"] = { 
+                            stage("Build ${image}") {
+                                try {
+                                    dir(workspacePath) {
+                                        buildImage(image)
+                                    }
+                                    registerBuiltImage(image)
+                                } catch (err) {
+                                    registerBuildFailedImage(image)
+                                    util.archiveConsoleLog(image)
+                                    throw err
+                                }
+                            }
+                            stage("Test ${image}") {
+                                dir(workspacePath) {
+                                    try {
+                                        testImage(image)
+                                    } catch (err) {
+                                        registerTestFailedImage(image)
+                                    } finally {
+                                        junit testResults: "target/test/results/*.xml", allowEmptyResults: true
+                                        archiveArtifacts artifacts: "target/test/results/*.xml", allowEmptyArchive: true
+                                    }
+                                }
+                            }
+                        }
                     }
-                }
-            }
-        }
-        stage('Test Images') {
-            when {
-                expression { return !params.SKIP_TESTS }
-            }
-            steps {
-                script {
-                    // Init workspaces before test
-                    getImages().each { image -> initWorkspace(image) }
-                    // Test images
-                    launchParallelForEachImage('Test', { img -> testImage(img) })
+                    parallel parallelStages
                 }
             }
             post {
@@ -278,9 +287,17 @@ pipeline {
                         getBuiltImages().each {
                             prBody += "- ${it}\n"
                         }
-                        if (getFailedImages()){
-                            prBody += '\nFailed images:\n'
-                            getFailedImages().each {
+                        if (getBuildFailedImages()){
+                            prBody += '\nBuild failures on those images:\n'
+                            getBuildFailedImages().each {
+                                prBody += "- ${it}\n"
+                            }
+                        } else {
+                            prBody += '\nImages were all successfully built but some other problem occured in the pipeline execution...\n'
+                        }
+                        if (getTestFailedImages()){
+                            prBody += '\nTest failures on those images:\n'
+                            getTestFailedImages().each {
                                 prBody += "- ${it}\n"
                             }
                         } else {
@@ -327,7 +344,7 @@ pipeline {
 
 void sendUnsuccessfulNotification() {
     if (params.SEND_NOTIFICATION) {
-        sendNotification("**Deploy job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}")
+        mailer.sendMarkdownTestSummaryNotification('Deploy', getNotificationSubject(), [env.KOGITO_CI_EMAIL_TO])
     } else {
         echo 'No notification sent per configuration'
     }
@@ -335,8 +352,12 @@ void sendUnsuccessfulNotification() {
 
 void sendNotification(String body) {
     emailext body: body,
-        subject: "[${getBuildBranch()}] Kogito Images",
+        subject: getNotificationSubject(),
         to: env.KOGITO_CI_EMAIL_TO
+}
+
+String getNotificationSubject() {
+    return "[${getBuildBranch()}] Kogito Images"
 }
 
 void checkoutRepo() {
@@ -362,49 +383,29 @@ void cleanImages() {
     sh "${env.CONTAINER_ENGINE} rmi -f \$(${env.CONTAINER_ENGINE} images -q) || date"
 }
 
-void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
-    parallelStages = [:]
-    getImages().each { image ->
-        parallelStages["${stageNamePrefix} ${image}"] = {
-            dir(getWorkspacePath(image)) {
-                executeOnImage(image)
-            }
-        }
-    }
-    parallel parallelStages
+void buildImage(String imageName) {
+    sh "make build-image image_name=${imageName} ignore_test=true cekit_option='--work-dir .'"
 }
 
-void buildImage(image) {
-    try {
-        sh "make build-image image_name=${image} ignore_test=true cekit_option='--work-dir .'"
-        registerBuiltImage(image)
-    } catch (err) {
-        registerFailedImage(image)
-        unstable("${image} build failed")
-    }
-}
-
-void testImage(image) {
-    try {
-        sh "make build-image image_name=${image} ignore_build=true cekit_option='--work-dir .'"
-    } catch (err) {
-        removeBuiltImage (image)
-        registerFailedImage(image)
-        unstable("${image} testing failed")
-    } finally {
-        junit testResults: 'target/test/results/*.xml', allowEmptyResults: true
-    }
+void testImage(String imageName) {
+    sh "make build-image image_name=${imageName} ignore_build=true cekit_option='--work-dir .'"
 }
 
 void registerBuiltImage(String imageName) {
-    lock("${BUILD_URL}") {
+    lock("${BUILD_URL} build success") {
         BUILT_IMAGES.add(imageName)
     }
 }
 
-void registerFailedImage(String imageName) {
-    lock("${BUILD_URL}") {
-        FAILED_IMAGES.add(imageName)
+void registerBuildFailedImage(String imageName) {
+    lock("${BUILD_URL} build failed") {
+        BUILD_FAILED_IMAGES.add(imageName)
+    }
+}
+
+void registerTestFailedImage(String imageName) {
+    lock("${BUILD_URL} test failed") {
+        TEST_FAILED_IMAGES.add(imageName)
     }
 }
 
@@ -418,8 +419,12 @@ List getBuiltImages() {
     return BUILT_IMAGES
 }
 
-List getFailedImages() {
-    return FAILED_IMAGES
+List getBuildFailedImages() {
+    return BUILD_FAILED_IMAGES
+}
+
+List getTestFailedImages() {
+    return TEST_FAILED_IMAGES
 }
 
 void tagImages() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -202,7 +202,7 @@ pipeline {
 
 void sendUnsuccessfulNotification() {
     if (params.SEND_NOTIFICATION) {
-        sendNotification("**Promote job** #${BUILD_NUMBER} was: ${currentBuild.currentResult}\nPlease look here: ${BUILD_URL}")
+        mailer.sendMarkdownTestSummaryNotification('Promote', getNotificationSubject(), [env.KOGITO_CI_EMAIL_TO])
     } else {
         echo 'No notification sent per configuration'
     }
@@ -210,8 +210,12 @@ void sendUnsuccessfulNotification() {
 
 void sendNotification(String body, String subjectProject = 'Kogito Images') {
     emailext body: body,
-        subject: "[${getBuildBranch()}] ${subjectProject}",
+        subject: getNotificationSubject()
         to: env.KOGITO_CI_EMAIL_TO
+}
+
+String getNotificationSubject() {
+    return "[${getBuildBranch()}] Kogito Images"
 }
 
 void installGitHubReleaseCLI() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -47,7 +47,11 @@ if (Utils.isLTSBranch(this)) {
 
 void setupPrJob(String branch = "${GIT_BRANCH}") {
     def jobParams = getDefaultJobParams()
-    jobParams.pr.run_only_for_branches = [ branch ]
+    jobParams.pr.putAll([
+        run_only_for_branches: [ branch ],
+        disable_status_message_error: true,
+        disable_status_message_failure: true,
+    ])
     KogitoJobTemplate.createPRJob(this, jobParams)
 }
 

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -22,4 +22,4 @@ jobs:
         java-version: 11
       
     - name: Test DSL
-      run: cd .ci/jenkins/dsl && ./test.sh
+      run: cd .ci/jenkins/dsl && ./test.sh 1.13.x


### PR DESCRIPTION
Depends on https://github.com/kiegroup/kogito-pipelines/pull/388

I backported changes from `main` which are useful and removed drools references.

- https://github.com/kiegroup/kogito-pipelines/pull/388
- https://github.com/kiegroup/kogito-pipelines/pull/390
- https://github.com/kiegroup/kogito-runtimes/pull/2028
- https://github.com/kiegroup/optaplanner/pull/1850
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/662
- https://github.com/kiegroup/optaweb-employee-rostering/pull/771
- https://github.com/kiegroup/optaplanner-quickstarts/pull/295
- https://github.com/kiegroup/kogito-apps/pull/1258
- https://github.com/kiegroup/kogito-examples/pull/1144
- https://github.com/kiegroup/kogito-images/pull/1126
- https://github.com/kiegroup/kogito-operator/pull/1139