### PR TITLE
[RHPAM-4195] Enable multi-arch for existing builder and runtime JVM images

### DIFF
--- a/content_sets.yaml
+++ b/content_sets.yaml
@@ -18,8 +18,8 @@ x86_64:
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
-  - openj9-1-for-rhel-8-s390x-rpms
+  - rhocp-4.7-for-rhel-8-s390x-rpms
 ppc64le:
   - rhel-8-for-ppc64le-baseos-rpms
   - rhel-8-for-ppc64le-appstream-rpms
-  - openj9-1-for-rhel-8-ppc64le-rpms
+  - rhocp-4.7-for-rhel-8-ppc64le-rpms

--- a/modules/kogito-graalvm-installer/20.x-java-1.8/configure
+++ b/modules/kogito-graalvm-installer/20.x-java-1.8/configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+architecture=$(uname -i)
+
+if [ "$architecture" != x86_64 ]; then
+    exit 0;
+fi
+
 SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname "${0}")
 
@@ -11,4 +17,3 @@ mv /usr/share/graalvm-ce-java"${GRAALVM_JAVA_VERSION}"-"${GRAALVM_VERSION}" /usr
 mkdir -p "${KOGITO_HOME}"/ssl-libs
 cp -v "$GRAALVM_HOME"/jre/lib/amd64/libsunec.so "${KOGITO_HOME}"/ssl-libs
 cp -v "$GRAALVM_HOME"/jre/lib/security/cacerts "${KOGITO_HOME}"/
-

--- a/modules/kogito-graalvm-installer/20.x-java-11/configure
+++ b/modules/kogito-graalvm-installer/20.x-java-11/configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+architecture=$(uname -i)
+
+if [ "$architecture" != x86_64 ]; then
+    exit 0;
+fi
+
 SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname "${0}")
 
@@ -11,4 +17,3 @@ mv /usr/share/graalvm-ce-java"${GRAALVM_JAVA_VERSION}"-"${GRAALVM_VERSION}" /usr
 mkdir -p "${KOGITO_HOME}"/ssl-libs
 cp -v "$GRAALVM_HOME"/lib/libsunec.so "${KOGITO_HOME}"/ssl-libs
 cp -v "$GRAALVM_HOME"/lib/security/cacerts "${KOGITO_HOME}"/
-

--- a/modules/kogito-graalvm-installer/21.x-java-11/configure
+++ b/modules/kogito-graalvm-installer/21.x-java-11/configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+architecture=$(uname -i)
+
+if [ "$architecture" != x86_64 ]; then
+    exit 0;
+fi
+
 SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname "${0}")
 
@@ -11,4 +17,3 @@ mv /usr/share/graalvm-ce-java"${GRAALVM_JAVA_VERSION}"-"${GRAALVM_VERSION}" /usr
 mkdir -p "${KOGITO_HOME}"/ssl-libs
 cp -v "$GRAALVM_HOME"/lib/libsunec.so "${KOGITO_HOME}"/ssl-libs
 cp -v "$GRAALVM_HOME"/lib/security/cacerts "${KOGITO_HOME}"/
-

--- a/modules/kogito-graalvm-scripts/configure
+++ b/modules/kogito-graalvm-scripts/configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+architecture=$(uname -i)
+
+if [ "$architecture" != x86_64 ]; then
+    exit 0;
+fi
+
 SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname "${0}")
 

--- a/rhpam-kogito-builder-rhel8-overrides.yaml
+++ b/rhpam-kogito-builder-rhel8-overrides.yaml
@@ -70,7 +70,13 @@ packages:
 
 osbs:
   configuration:
-    container_file: container.yaml
+    container:
+      platforms:
+        only:
+          - x86_64
+          - ppc64le
+      compose:
+        pulp_repos: true
   extra_dir: osbs-extra/rhpam-kogito-builder-rhel8
   repository:
     name: containers/rhpam-7-kogito-builder

--- a/rhpam-kogito-runtime-jvm-rhel8-overrides.yaml
+++ b/rhpam-kogito-runtime-jvm-rhel8-overrides.yaml
@@ -51,7 +51,13 @@ packages:
 
 osbs:
   configuration:
-    container_file: container.yaml
+    container:
+      platforms:
+        only:
+          - x86_64
+          - ppc64le
+      compose:
+        pulp_repos: true
   extra_dir: osbs-extra/rhpam-kogito-runtime-jvm-rhel8
   repository:
     name: containers/rhpam-7-kogito-runtime-jvm


### PR DESCRIPTION
JIRA issue : https://issues.redhat.com/browse/RHPAM-4195

Enable ppc64le only since s390x was dropped. There are some workarounds added to graalvm configuration scripts to check the arch to avoid us having to add a whole new image because of those unsupported native packages.

(cherry picked from commit 6e8f388231c6121a9f8fd4990009e267b01e2ce7)
