### PR TITLE
[KOGITO-7781] Trials with Kogito Serverless Workflow base builder image

### DIFF
--- a/kogito-serverless-workflow-base-overrides.yaml
+++ b/kogito-serverless-workflow-base-overrides.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+
+name: "quay.io/kiegroup/kogito-serverless-workflow-base"
+description: "Base Image for Kogito Serverless Workflow projects"
+
+labels:
+  - name: "maintainer"
+    value: "kogito <bsig-cloud@redhat.com>"
+  - name: "io.k8s.description"
+    value: "Base Image for Kogito Serverless Workflow projects"
+  - name: "io.k8s.display-name"
+    value: "Kogito Serverless Workflow Base"
+  - name: "io.openshift.tags"
+    value: "kogito,serverless workflow,knative,cncf"
+  - name: "io.openshift.expose-services"
+    value: "8080:http"
+
+envs:
+  - name: SCRIPT_DEBUG
+    example: "true"
+    description: "If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed. Also debug JVM initialization."
+  - name: JAVA_OPTIONS
+    example: "-Dquarkus.log.level=DEBUG"
+    description: JVM options passed to the Java command.
+  - name: QUARKUS_PROJECT_NAME
+    value: kogito-sw-base
+  - name: QUARKUS_EXTENSIONS
+    value: "kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing,resteasy-reactive-jackson,quarkus-kubernetes"
+
+ports:
+  - value: 8080
+
+modules:
+  install:
+    - name: org.kie.kogito.image.dependencies
+    - name: org.kie.kogito.system.user
+    - name: org.kie.kogito.logging
+    - name: org.kie.kogito.launch.scripts
+    - name: org.kie.kogito.openjdk
+      version: "11"
+    - name: org.kie.kogito.dynamic.resources
+    - name: org.kie.kogito.maven
+      version: 3.8.6
+    - name: org.kie.kogito.quarkus.project
+
+run:
+  workdir: "/home/kogito"
+  cmd:
+    - "/home/kogito/kogito-quarkus-launch.sh"

--- a/modules/kogito-quarkus-project/configure
+++ b/modules/kogito-quarkus-project/configure
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+# Requires maven, jdk, and user modules
+# Generates a new Quarkus project in /home/kogito
+
+# [in] QUARKUS_VERSION
+# [in] QUARKUS_PROJECT_NAME
+# [in] QUARKUS_EXTENSIONS (comma separated)
+
+#   [ ] TODO: check java
+#   [ ] TODO: check maven
+#   [ ] TODO: check directory
+
+# For downstream, a Quarkus registry can be used. In this case, the Maven settings also should be configured with Red Hat's repo.
+
+SCRIPT_DIR=$(dirname "${0}")
+ADDED_DIR="${SCRIPT_DIR}"/added
+
+cd ${KOGITO_HOME}
+
+${MAVEN_HOME}/bin/mvn -U -B ${MAVEN_ARGS_APPEND} -s "${MAVEN_SETTINGS_PATH}" \
+        io.quarkus.platform:quarkus-maven-plugin:${QUARKUS_VERSION}:create \
+        -DprojectGroupId=org.acme \
+        -DprojectArtifactId=${QUARKUS_PROJECT_NAME} \
+        -DplatformVersion=${QUARKUS_VERSION} \
+        -Dextensions="${QUARKUS_EXTENSIONS}"
+
+cd ${QUARKUS_PROJECT_NAME}
+
+${MAVEN_HOME}/bin/mvn -U -B clean install -DskipTests -Dquarkus.container-image.build=false
+
+mv /root/.m2/repository ${KOGITO_HOME}/.m2/
+
+chown -R 1001:0 "${KOGITO_HOME}"
+chmod -R ug+rwX "${KOGITO_HOME}"
+
+# TODO: add a script saying that this image is not meant to run

--- a/modules/kogito-quarkus-project/module.yaml
+++ b/modules/kogito-quarkus-project/module.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+name: org.kie.kogito.quarkus.project
+version: "2.0.0-snapshot"
+description: "Module that generates a Quarkus project with required extensions"
+
+execute:
+  - script: configure
+
+# QUARKUS_VERSION must be aligned with Kogito
+
+envs:
+  - name: QUARKUS_VERSION
+    value: 2.11.2.Final
+  - name: QUARKUS_PROJECT_NAME
+    value: kogito-sw-base
+    example: acme-test
+  - name: QUARKUS_EXTENSIONS
+    value: "kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing,quarkus-kubernetes"


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

In this PR, we introduce a new module: Quarkus, that can create a quarkus project with any extensions. This module provides an image with a Maven repository in the cache so that multi-stage builders can run quickly. See an example here: https://gist.github.com/ricardozanini/0a8a4e02d5f39b27c94cf35fa1687514.

This multi-stage builder took 16s to run.

Please don't merge this PR. Work in progress that depends on this image is still ongoing.

TODO:
- [ ] Improve the quarkus module to turn it into something generic; in theory, we could build any kind of quarkus skeleton project. Problem: the env vars can't be overrides by the image overrides (??)
- [ ] Write behavior tests
- [ ] Write unit tests
- [ ] Improve the. shell scripting and documentation

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change