### PR TITLE
KOGITO- 8275 Build `kogito-swf-builder` quarkus app locally

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -1,5 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
+import org.kie.jenkins.MavenCommand
+
 changeAuthor = env.ghprbAuthorRepoGitUrl ? util.getGroup(env.ghprbAuthorRepoGitUrl) : (env.ghprbPullAuthorLogin ?: CHANGE_AUTHOR)
 changeBranch = env.ghprbSourceBranch ?: CHANGE_BRANCH
 changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
@@ -7,7 +9,9 @@ changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
 BUILD_FAILED_IMAGES = []
 
 pipeline {
-    agent { label 'kogito-image-slave && !built-in' }
+    agent { 
+        label 'kogito-image-slave && !built-in' 
+    }
     tools {
         jdk 'kie-jdk11'
     }
@@ -27,14 +31,9 @@ pipeline {
                     if (env.MAVEN_MIRROR_REPOSITORY != null
                             && env.MAVEN_MIRROR_REPOSITORY != '') {
                         env.MAVEN_MIRROR_URL = env.MAVEN_MIRROR_REPOSITORY
-                            }
+                    }
 
                     githubscm.checkoutIfExists('kogito-images', changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
-
-                    //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
-                    if (env.MAVEN_MIRROR_URL != '') {
-                        sh 'python3 scripts/update-tests.py --ignore-self-signed-cert'
-                    }
                 }
             }
         }
@@ -52,9 +51,16 @@ pipeline {
                 }
             }
         }
-        stage('Prepare offline kogito-examples') {
+        stage('Prepare for tests') {
             steps {
-                sh 'make clone-repos'
+                script {
+                    //Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
+                    if (env.MAVEN_MIRROR_URL != '') {
+                        sh 'python3 scripts/update-tests.py --ignore-self-signed-cert'
+                    }
+
+                    sh 'make clone-repos'
+                }
             }
         }
         stage('Build & Test Images') {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGE_VERSION := $(shell cat image.yaml | egrep ^version  | cut -d"\"" -f2)
+QUARKUS_VERSION := $(shell awk '/- name: "QUARKUS_VERSION"/,/description/' image.yaml | grep value | awk -F'"' '{print $$2}')
 SHORTENED_LATEST_VERSION := $(shell echo $(IMAGE_VERSION) | awk -F. '{print $$1"."$$2}')
 KOGITO_APPS_TARGET_BRANCH ?= main
 KOGITO_APPS_TARGET_URI ?= https://github.com/kiegroup/kogito-apps.git
@@ -36,6 +37,7 @@ build-image: clone-repos _build-image
 _build-image:
 ifneq ($(ignore_build),true)
 	scripts/build-kogito-apps-components.sh ${image_name} ${KOGITO_APPS_TARGET_BRANCH} ${KOGITO_APPS_TARGET_URI};
+	scripts/build-quarkus-app.sh ${image_name} $(QUARKUS_VERSION)
 	${CEKIT_CMD} build --overrides-file ${image_name}-overrides.yaml ${BUILD_ENGINE}
 endif
 # if ignore_test is set to true, ignore the tests

--- a/image.yaml
+++ b/image.yaml
@@ -19,10 +19,10 @@ modules:
 envs:
   - name: "KOGITO_VERSION"
     value: "2.0.0-SNAPSHOT"
-    description: Please do not change
+    description: Defines the Kogito version to be used by the builder images. Not intended to be changed by end user.
   - name: "QUARKUS_VERSION"
     value: "2.14.1.Final"
-    description: Please do not change
+    description: Defines the Quarkus version to be used by the builder images. Not intended to be changed by end user.
 
 packages:
   manager: microdnf

--- a/image.yaml
+++ b/image.yaml
@@ -19,6 +19,10 @@ modules:
 envs:
   - name: "KOGITO_VERSION"
     value: "2.0.0-SNAPSHOT"
+    description: Please do not change
+  - name: "QUARKUS_VERSION"
+    value: "2.14.1.Final"
+    description: Please do not change
 
 packages:
   manager: microdnf

--- a/modules/kogito-maven/3.8.x/module.yaml
+++ b/modules/kogito-maven/3.8.x/module.yaml
@@ -5,7 +5,7 @@ version: "3.8.6"
 envs:
   - name: "MAVEN_VERSION"
     value: "3.8.6"
-  - name: " MAVEN_HOME"
+  - name: "MAVEN_HOME"
     value: "/usr/share/maven"
   - name: "MAVEN_SETTINGS_PATH"
     description: "The location of the settings.xml file"

--- a/modules/kogito-s2i-core/module.yaml
+++ b/modules/kogito-s2i-core/module.yaml
@@ -42,10 +42,6 @@ envs:
     description: ^ Defines the maven artifact for Quarkus Maven plugin, defaults to io.quarkus:quarkus-maven-plugin. If no version specified it will be detected automatically based on the current Kogito version.
     example: "io.quarkus:custom-plugin:custom.version"
 
-  - name: QUARKUS_VERSION
-    description: ^ Defines the Quarkus version to ve using during normal or from assets maven builds.
-    example: "2.23.0.Final"
-
   - name: QUARKUS_PLATFORM_GROUP_ID
     description: ^ Defines the Quarkus platform group id, defaults to io.quarkus.platform for community and com.redhat.quarkus.platform for product.
     example: "io.quarkus.custom"

--- a/modules/kogito-swf-builder/added/add-extension.sh
+++ b/modules/kogito-swf-builder/added/add-extension.sh
@@ -4,17 +4,18 @@ set -e
 script_dir_path="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 extensions="$1"
 
-# Call the configure-maven here
-source "${script_dir_path}"/configure-maven.sh
-configure
-
 source "${script_dir_path}"/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
+    export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -X --batch-mode" 
     log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
     printenv
 fi
+
+# Call the configure-maven here
+source "${script_dir_path}"/configure-maven.sh
+configure
 
 cd "${PROJECT_ARTIFACT_ID}"
 

--- a/modules/kogito-swf-builder/added/add-extension.sh
+++ b/modules/kogito-swf-builder/added/add-extension.sh
@@ -5,10 +5,10 @@ script_dir_path="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 extensions="$1"
 
 # Call the configure-maven here
-source "${KOGITO_HOME}"/launch/configure-maven.sh
+source "${script_dir_path}"/configure-maven.sh
 configure
 
-source "${KOGITO_HOME}"/launch/logging.sh
+source "${script_dir_path}"/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
@@ -16,7 +16,7 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     printenv
 fi
 
-cd "${KOGITO_HOME}/${PROJECT_ARTIFACT_ID}"
+cd "${PROJECT_ARTIFACT_ID}"
 
 "${MAVEN_HOME}"/bin/mvn -U -B -s "${MAVEN_SETTINGS_PATH}" \
 io.quarkus.platform:quarkus-maven-plugin:"${QUARKUS_VERSION}":add-extension ${QUARKUS_ADD_EXTENSION_ARGS}\

--- a/modules/kogito-swf-builder/added/build-app.sh
+++ b/modules/kogito-swf-builder/added/build-app.sh
@@ -7,17 +7,18 @@ if [ ! -z "${resources_path}" ]; then
   resources_path="$(realpath "${resources_path}")"
 fi
 
-# Call the configure-maven here
-source "${script_dir_path}"/configure-maven.sh
-configure
-
 source "${script_dir_path}"/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
+    export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -X --batch-mode" 
     log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
     printenv
 fi
+
+# Call the configure-maven here
+source "${script_dir_path}"/configure-maven.sh
+configure
 
 cd "${PROJECT_ARTIFACT_ID}"
 

--- a/modules/kogito-swf-builder/added/build-app.sh
+++ b/modules/kogito-swf-builder/added/build-app.sh
@@ -8,10 +8,10 @@ if [ ! -z "${resources_path}" ]; then
 fi
 
 # Call the configure-maven here
-source "${KOGITO_HOME}"/launch/configure-maven.sh
+source "${script_dir_path}"/configure-maven.sh
 configure
 
-source "${KOGITO_HOME}"/launch/logging.sh
+source "${script_dir_path}"/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
@@ -19,7 +19,7 @@ if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     printenv
 fi
 
-cd "${KOGITO_HOME}/${PROJECT_ARTIFACT_ID}"
+cd "${PROJECT_ARTIFACT_ID}"
 
 if [ ! -z "${QUARKUS_EXTENSIONS}" ]; then
   ${script_dir_path}/add-extension.sh "${QUARKUS_EXTENSIONS}"

--- a/modules/kogito-swf-builder/added/create-app.sh
+++ b/modules/kogito-swf-builder/added/create-app.sh
@@ -3,17 +3,18 @@ set -e
 
 script_dir_path="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
-# Call the configure-maven here
-source "${script_dir_path}"/configure-maven.sh
-configure
-
 source "${script_dir_path}"/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
+    export MAVEN_ARGS_APPEND="${MAVEN_ARGS_APPEND} -X --batch-mode" 
     log_info "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
     printenv
 fi
+
+# Call the configure-maven here
+source "${script_dir_path}"/configure-maven.sh
+configure
 
 "${MAVEN_HOME}"/bin/mvn -U -B -s "${MAVEN_SETTINGS_PATH}" \
 io.quarkus.platform:quarkus-maven-plugin:"${QUARKUS_VERSION}":create ${QUARKUS_CREATE_ARGS} \

--- a/modules/kogito-swf-builder/added/create-app.sh
+++ b/modules/kogito-swf-builder/added/create-app.sh
@@ -3,13 +3,11 @@ set -e
 
 script_dir_path="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 
-cd "${KOGITO_HOME}"
-
 # Call the configure-maven here
-source "${KOGITO_HOME}"/launch/configure-maven.sh
+source "${script_dir_path}"/configure-maven.sh
 configure
 
-source "${KOGITO_HOME}"/launch/logging.sh
+source "${script_dir_path}"/logging.sh
 
 if [ "${SCRIPT_DEBUG}" = "true" ] ; then
     set -x
@@ -23,7 +21,7 @@ io.quarkus.platform:quarkus-maven-plugin:"${QUARKUS_VERSION}":create ${QUARKUS_C
 -DprojectArtifactId="${PROJECT_ARTIFACT_ID}" \
 -DprojectVersionId="${PROJECT_VERSION}" \
 -DplatformVersion="${QUARKUS_VERSION}" \
--Dextensions="${quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing}"
+-Dextensions="${QUARKUS_EXTENSIONS}"
 
 cd "${PROJECT_ARTIFACT_ID}"
 

--- a/modules/kogito-swf-builder/configure.sh
+++ b/modules/kogito-swf-builder/configure.sh
@@ -2,12 +2,21 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCES_DIR=/tmp/artifacts
 ADDED_DIR="${SCRIPT_DIR}"/added
 LAUNCH_DIR="${KOGITO_HOME}"/launch
 
 cp -v "${ADDED_DIR}"/create-app.sh "${LAUNCH_DIR}"
 cp -v "${ADDED_DIR}"/add-extension.sh "${LAUNCH_DIR}"
 cp -v "${ADDED_DIR}"/build-app.sh "${LAUNCH_DIR}"
+
+# Quarkus app
+unzip "${SOURCES_DIR}"/kogito-swf-builder-quarkus-app.zip -d "${KOGITO_HOME}"
+ls -al "${KOGITO_HOME}"
+
+# Maven repository
+unzip "${SOURCES_DIR}"/kogito-swf-builder-maven-repo.zip -d "${KOGITO_HOME}"/.m2/repository
+ls -al "${KOGITO_HOME}/.m2/repository"
 
 chown -R 1001:0 "${KOGITO_HOME}"
 chmod -R ug+rwX "${KOGITO_HOME}"

--- a/modules/kogito-swf-builder/configure.sh
+++ b/modules/kogito-swf-builder/configure.sh
@@ -10,13 +10,9 @@ cp -v "${ADDED_DIR}"/create-app.sh "${LAUNCH_DIR}"
 cp -v "${ADDED_DIR}"/add-extension.sh "${LAUNCH_DIR}"
 cp -v "${ADDED_DIR}"/build-app.sh "${LAUNCH_DIR}"
 
-# Quarkus app
+# Unzip Quarkus app and Maven repository
 unzip "${SOURCES_DIR}"/kogito-swf-builder-quarkus-app.zip -d "${KOGITO_HOME}"
-ls -al "${KOGITO_HOME}"
-
-# Maven repository
 unzip "${SOURCES_DIR}"/kogito-swf-builder-maven-repo.zip -d "${KOGITO_HOME}"/.m2/repository
-ls -al "${KOGITO_HOME}/.m2/repository"
 
 chown -R 1001:0 "${KOGITO_HOME}"
 chmod -R ug+rwX "${KOGITO_HOME}"

--- a/modules/kogito-swf-builder/module.yaml
+++ b/modules/kogito-swf-builder/module.yaml
@@ -4,28 +4,31 @@ version: "2.0.0-snapshot"
 description: "Kogito Serverless Workflow builder with required extensions"
 
 envs:
-  - name: PROJECT_GROUP_ID
-    value: "org.acme"
-    description: Please do not change
-  - name: PROJECT_ARTIFACT_ID
-    value: "serverless-workflow-project"
-    description: Please do not change
-  - name: PROJECT_VERSION
-    value: "1.0.0-SNAPSHOT"
-    description: Please do not change
-  - name: QUARKUS_VERSION
-    value: "2.14.1.Final"
-    description: Please do not change
   - name: QUARKUS_EXTENSIONS
     example: 'quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing'
     description: To add extension to your application
+  - name: PROJECT_GROUP_ID
+    value: "org.acme"
+    description: Please do not change. To change only if you plan to use the ${KOGITO_HOME}/launch/create-app.sh
+  - name: PROJECT_ARTIFACT_ID
+    value: "serverless-workflow-project"
+    description: Please do not change. To change only if you plan to use the ${KOGITO_HOME}/launch/create-app.sh
+  - name: PROJECT_VERSION
+    value: "1.0.0-SNAPSHOT"
+    description: Please do not change. To change only if you plan to use the ${KOGITO_HOME}/launch/create-app.sh
   - name: QUARKUS_CREATE_ARGS
     example: -DnoCode
     description: To use only if you plan to use the ${KOGITO_HOME}/launch/create-app.sh
   - name: QUARKUS_ADD_EXTENSION_ARGS
     description: To use only if you plan to use the ${KOGITO_HOME}/launch/add-extension.sh
 
+# see build-quarkus-app.sh script, responsible for building those artifacts.
+# called by the Makefile before builds
+artifacts:
+  - path: /tmp/build/kogito-swf-builder/kogito-swf-builder-quarkus-app.zip
+    name: kogito-swf-builder-quarkus-app.zip
+  - path: /tmp/build/kogito-swf-builder/kogito-swf-builder-maven-repo.zip
+    name: kogito-swf-builder-maven-repo.zip
+
 execute:
   - script: configure.sh
-  - script: added/create-app.sh
-    user: kogito

--- a/scripts/build-quarkus-app.sh
+++ b/scripts/build-quarkus-app.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Parameters:
+#   1 - image name - can't  be empty.
+#   2 - git target branch - defaults to main
+#   3 - git target uri - defaults to https://github.com/kiegroup/kogito-apps.git
+
+# fast fail
+set -e
+set -o pipefail
+
+# Read entries before sourcing
+image_name="${1}"
+quarkus_version="${2}"
+
+if [ -z ${quarkus_version} ]; then
+    echo "Please provide the quarkus version"
+    exit 1
+fi
+
+case ${image_name} in
+    "kogito-swf-builder")        ;;
+    *)
+        echo "${image_name} is not a quarkus app image, exiting..."
+        exit 0
+        ;;
+esac
+
+
+script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
+
+target_tmp_dir="/tmp/build/kogito-swf-builder"
+build_target_dir="/tmp/kogito-swf-builder"
+mvn_local_repo="/tmp/temp_maven/kogito-swf-builder"
+
+rm -rf ${target_tmp_dir} && mkdir -p ${target_tmp_dir}
+rm -rf ${build_target_dir} && mkdir -p ${build_target_dir}
+mkdir -p ${mvn_local_repo}
+
+. ${script_dir_path}/setup-maven.sh "${build_target_dir}"/settings.xml
+
+echo "Copy current maven repo to maven context local repo ${mvn_local_repo}"
+cp -r ${HOME}/.m2/repository/* "${mvn_local_repo}"
+
+set -x
+
+echo "Create quarkus project to path ${build_target_dir}"
+cd ${build_target_dir}
+mvn -U "${MAVEN_OPTIONS}" \
+    io.quarkus.platform:quarkus-maven-plugin:"${quarkus_version}":create \
+    -Dmaven.repo.local=${mvn_local_repo} \
+    -DprojectGroupId="org.acme" \
+    -DprojectArtifactId="serverless-workflow-project" \
+    -DprojectVersionId="1.0.0-SNAPSHOT" \
+    -DplatformVersion="${quarkus_version}" \
+    -Dextensions="quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing"
+
+echo "Build quarkus app"
+cd "serverless-workflow-project"
+mvn ${MAVEN_OPTIONS} -U clean install -DskipTests -Dmaven.repo.local=${mvn_local_repo} -Dquarkus.container-image.build=false
+
+cd ${build_target_dir}
+echo "Zip and copy scaffold project"
+cd ${build_target_dir}/
+zip -r kogito-swf-builder-quarkus-app.zip serverless-workflow-project/ 
+cp -v kogito-swf-builder-quarkus-app.zip ${target_tmp_dir}/
+echo "Zip and copy maven repo"
+cd ${mvn_local_repo}
+zip -r kogito-swf-builder-maven-repo.zip *
+cp -v kogito-swf-builder-maven-repo.zip ${target_tmp_dir}/


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-8275

@desmax74 @spolti I changed the way the kogito-swf-builder is built
The scaffold project is no more built during the cekit build but before and we copy project and maven repo to the image
This is done so that we can use specific Maven configuration on the scaffold project creation and build, based on node env variables. We cannot do that if the build happens on Cekit

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change