### PR TITLE
[1.13.x] use 8.6 tag of ubi8 image for building kogito-builder and kogito-runtime-jvm images

### DIFF
--- a/rhpam-kogito-builder-rhel8-overrides.yaml
+++ b/rhpam-kogito-builder-rhel8-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "rhpam-7/rhpam-kogito-builder-rhel8"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 description: "RHPAM Platform for building Kogito based on Quarkus or SpringBoot"
 
 labels:

--- a/rhpam-kogito-runtime-jvm-rhel8-overrides.yaml
+++ b/rhpam-kogito-runtime-jvm-rhel8-overrides.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "rhpam-7/rhpam-kogito-runtime-jvm-rhel8"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 description: "RHPAM Runtime image for Kogito based on Quarkus or SpringBoot JVM image"
 
 labels:


### PR DESCRIPTION
This is required for now as latest ubi8 tag is using a RHEL 8.7 which seems to contain a bug and it is pulling an old version of nss package which is affected by a critical CVE.

Related PRs:
- https://github.com/kiegroup/kogito-images/pull/1377
- https://github.com/kiegroup/kogito-images/pull/1378
- https://github.com/kiegroup/kogito-images/pull/1379

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change