### PR TITLE
[SRVLOGIC-76] Data-index prod ephemeral image is missing the KOGITO_D…

### DIFF
--- a/logic-data-index-ephemeral-rhel8-overrides.yaml
+++ b/logic-data-index-ephemeral-rhel8-overrides.yaml
@@ -20,6 +20,9 @@ envs:
   - name: "SCRIPT_DEBUG"
     example: "true"
     description: "If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed. Also debug JVM initialization."
+  - name: "KOGITO_DATA_INDEX_QUARKUS_PROFILE"
+    value: "http-events-support"
+    description: "Allows to change the event connection type. The possible values are :`kafka-events-support` or `http-events-support`(default)"
 ports:
 - value: 8080
 

--- a/modules/kogito-data-index-ephemeral/prod/added/kogito-app-launch.sh
+++ b/modules/kogito-data-index-ephemeral/prod/added/kogito-app-launch.sh
@@ -14,6 +14,7 @@ fi
 # Configuration scripts
 # Any configuration script that needs to run on image startup must be added here.
 CONFIGURE_SCRIPTS=(
+    "${KOGITO_HOME}"/launch/kogito-data-index-common.sh
     "${KOGITO_HOME}"/launch/configure-custom-truststore.sh
 )
 source "${KOGITO_HOME}"/launch/configure.sh

--- a/tests/features/openshift-serverless-logic/logic-data-index-ephemeral.feature
+++ b/tests/features/openshift-serverless-logic/logic-data-index-ephemeral.feature
@@ -17,3 +17,9 @@ Feature: logic-data-index-ephemeral-rhel8 feature.
     And container log should contain Embedded Postgres started at port
     And container log should not contain Application failed to start
 
+  Scenario: check if the default quarkus profile is correctly set on data index
+    When container is started with env
+      | variable                           | value               |
+      | SCRIPT_DEBUG                       | true                |
+    Then container log should contain -Dquarkus.profile=http-events-support
+


### PR DESCRIPTION
…ATA_INDEX_QUARKUS_PROFILE

See: [SRVLOGIC-76](https://issues.redhat.com/browse/SRVLOGIC-76)

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [x] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [x] You've tested the new feature/bug fix in an actual OpenShift cluster
- [x] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>