### PR TITLE
KOGITO-8866: Ensure that Jobs Service is embedded in the workflow dev profile

### DIFF
--- a/scripts/build-quarkus-app.sh
+++ b/scripts/build-quarkus-app.sh
@@ -16,7 +16,7 @@ kogito_version="${KOGITO_VERSION:-${3}}"
 # common extensions used by the kogito-swf-builder and kogito-swf-devmode
 quarkus_extensions='quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing,smallrye-health'
 # dev mode purpose extensions used only by the kogito-swf-devmode
-kogito_swf_devmode_extensions='kogito-quarkus-serverless-workflow-devui,kogito-addons-quarkus-source-files,kogito-addons-quarkus-jobs-service-embedded'
+kogito_swf_devmode_extensions='kogito-quarkus-serverless-workflow-devui,kogito-addons-quarkus-source-files,kogito-addons-quarkus-jobs-service-embedded,kogito-addons-quarkus-data-index-inmemory'
 
 if [ -z ${quarkus_platform_version} ]; then
     echo "Please provide the quarkus version"

--- a/tests/features/kogito-swf-devmode.feature
+++ b/tests/features/kogito-swf-devmode.feature
@@ -30,3 +30,66 @@ Feature: SWF and Quarkus installation
       | wait                 | 480               |
       | request_method       | GET               |
       | expected_status_code | 200               |
+
+  Scenario: verify that the embedded jobs-service is running
+    When container is started with env
+      | variable                    | value |
+      | QUARKUS_DEVSERVICES_ENABLED | false |
+    Then container log should contain Embedded Postgres started at port
+    And container log should contain SET Leader
+    And check that page is served
+      | property             | value             |
+      | port                 | 8080              |
+      | path                 | /q/health/ready   |
+      | wait                 | 480               |
+      | request_method       | GET               |
+      | expected_status_code | 200               |
+    And check that page is served
+      | property             | value             |
+      | port                 | 8080              |
+      | path                 | /v2/jobs/1234     |
+      | wait                 | 480               |
+      | request_method       | GET               |
+      | expected_status_code | 404               |
+      | expected_phrase      | Job not found     |
+
+  Scenario: verify that the embedded data-index service is running
+    When container is started with env
+      | variable                    | value |
+      | QUARKUS_DEVSERVICES_ENABLED | false |
+    Then container log should contain Embedded Postgres started at port
+    And check that page is served
+      | property             | value             |
+      | port                 | 8080              |
+      | path                 | /q/health/ready   |
+      | request_method       | GET               |
+      | wait                 | 480               |
+      | expected_status_code | 200               |
+    And check that page is served
+      | property             | value                                    |
+      | port                 | 8080                                     |
+      | path                 | /graphql                                 |
+      | request_method       | POST                                     |
+      | request_body         | { "query": "{ProcessInstances{ id } }" } |
+      | wait                 | 480                                      |
+      | expected_status_code | 200                                      |
+      | expected_phrase      | {"data":{"ProcessInstances":[]}}         |
+
+  Scenario: verify that the serverless workflow devui is running
+    When container is started with env
+      | variable                    | value |
+      | QUARKUS_DEVSERVICES_ENABLED | false |
+    Then check that page is served
+      | property             | value                                                              |
+      | port                 | 8080                                                               |
+      | path                 | /q/dev/org.kie.kogito.kogito-quarkus-serverless-workflow/dataindex |
+      | request_method       | GET                                                                |
+      | wait                 | 480                                                                |
+      | expected_status_code | 200                                                                |
+    And check that page is served
+      | property             | value                                                                            |
+      | port                 | 8080                                                                             |
+      | path                 | /q/dev/org.kie.kogito.kogito-quarkus-serverless-workflow-devui/workflowInstances |
+      | request_method       | GET                                                                              |
+      | wait                 | 480                                                                              |
+      | expected_status_code | 200                                                                              |


### PR DESCRIPTION
    - incoporates the kogito-addons-quarkus-data-index-inmemory
    - and behave tests for the jobs-service, data-index and dev-ui

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [X] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [X] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Your feature/bug fix has a testcase that verifies it
- [X] You've tested the new feature/bug fix in an actual OpenShift cluster
- [X] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>