### PR TITLE
KOGITO-9181 Build multiplatform

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
                     assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
 
                     prepareForDockerMultiplatformBuild()
+                    startLocalRegistry()
                 }
             }
         }
@@ -159,6 +160,7 @@ void clean() {
     util.cleanNode(env.CONTAINER_ENGINE)
     
     cleanDockerMultiplatformBuild()
+    cleanLocalRegistry()
 
     // Clean Cekit cache, in case we reuse an old node
     sh "rm -rf \$HOME/.cekit/cache"
@@ -182,8 +184,15 @@ void buildImage(String imageName) {
 
     // Build multiplatform from generated Dockerfile
     String finalBuiltTag = getFullBuiltImageTag(imageName)
-    dir('target/image') {        
-        dockerBuildMultiPlatform(imageName, finalBuiltTag)
+    dir('target/image') {
+        // Use local registry
+        String internalRegistryImage = "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
+        dockerBuildMultiPlatform(internalRegistryImage)
+        // Pull and tag to final image
+        sh """
+            docker pull ${internalRegistryImage}
+            docker tag ${internalRegistryImage} ${finalBuiltTag}
+        """
     }
 }
 
@@ -262,8 +271,6 @@ List getBuildPlatforms() {
 void prepareForDockerMultiplatformBuild(boolean debug = false) {
     // For multiplatform build
     sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
-    // For pushing built images
-    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
     
     // Debug purpose
     if (debug) {
@@ -291,19 +298,23 @@ http = true
     }
 }
 
-void dockerBuildMultiPlatform(String imageName, String finalBuiltTag) {
+void dockerBuildMultiPlatform(String buildImageTag) {
     // Build image locally in tgz file
-    String internalRegistryImage = "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
     sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${internalRegistryImage} .
-        docker buildx imagetools inspect ${internalRegistryImage}
-        docker pull ${internalRegistryImage}
-        docker tag ${internalRegistryImage} ${finalBuiltTag}
+        docker buildx build --push --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${buildImageTag} .
+        docker buildx imagetools inspect ${buildImageTag}
     """
+}
+
+void startLocalRegistry() {
+    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
+}
+
+void cleanLocalRegistry() {
+    sh 'docker kill registry || true'
 }
 
 void cleanDockerMultiplatformBuild() {
     sh 'docker buildx rm mybuilder || true'
     sh 'docker kill binfmt || true'
-    sh 'docker kill registry || true'
 }

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -157,8 +157,8 @@ void clean() {
     cleanWorkspaces()
     util.cleanNode(env.CONTAINER_ENGINE)
     
-    cleanDockerMultiplatformBuild()
-    cleanLocalRegistry()
+    cloud.cleanDockerMultiplatformBuild()
+    cloud.cleanLocalRegistry()
 
     // Clean Cekit cache, in case we reuse an old node
     sh "rm -rf \$HOME/.cekit/cache"
@@ -258,53 +258,3 @@ void runPythonCommand(String cmd, boolean stdout = false) {
     return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
 }
 
-void prepareForDockerMultiplatformBuild(boolean debug = false) {
-    // For multiplatform build
-    sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
-    
-    // Debug purpose
-    if (debug) {
-        sh 'docker context ls'
-        sh 'docker buildx ls'
-        sh 'docker ps'
-    }
-    
-    writeFile(file: 'buildkitd.toml', text: '''
-debug = true
-[registry."docker.io"]
-mirrors = ["mirror.gcr.io"]
-[registry."localhost:5000"]
-http = true
-        ''')
-    
-    sh 'docker buildx rm mybuilder || true'
-    sh 'docker buildx create --name mybuilder --driver docker-container --driver-opt network=host --bootstrap --config ${WORKSPACE}/buildkitd.toml'
-    sh 'docker buildx use mybuilder'
-    
-    if (debug) {
-        sh 'docker buildx inspect'
-        sh 'docker buildx ls'
-        sh 'docker ps'
-    }
-}
-
-void dockerBuildMultiPlatform(String buildImageTag) {
-    // Build image locally in tgz file
-    sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${IMAGE_BUILD_PLATFORMS} -t ${buildImageTag} .
-        docker buildx imagetools inspect ${buildImageTag}
-    """
-}
-
-void startLocalRegistry() {
-    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
-}
-
-void cleanLocalRegistry() {
-    sh 'docker kill registry || true'
-}
-
-void cleanDockerMultiplatformBuild() {
-    sh 'docker buildx rm mybuilder || true'
-    sh 'docker kill binfmt || true'
-}

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -269,21 +269,25 @@ void prepareForDockerMultiplatformBuild(boolean debug = false) {
     if (debug) {
         sh 'docker context ls'
         sh 'docker buildx ls'
+        sh 'docker ps'
     }
     
     writeFile(file: 'buildkitd.toml', text: '''
 debug = true
 [registry."docker.io"]
 mirrors = ["mirror.gcr.io"]
+[registry."localhost:5000"]
+http = true
         ''')
     
     sh 'docker buildx rm mybuilder || true'
-    sh 'docker buildx create --name mybuilder --driver docker-container --bootstrap --config ${WORKSPACE}/buildkitd.toml'
+    sh 'docker buildx create --name mybuilder --driver docker-container --driver-opt network=host --bootstrap --config ${WORKSPACE}/buildkitd.toml'
     sh 'docker buildx use mybuilder'
     
     if (debug) {
         sh 'docker buildx inspect'
         sh 'docker buildx ls'
+        sh 'docker ps'
     }
 }
 
@@ -295,7 +299,6 @@ void dockerBuildMultiPlatform(String imageName, String finalBuiltTag) {
         docker buildx imagetools inspect ${internalRegistryImage}
         docker pull ${internalRegistryImage}
         docker tag ${internalRegistryImage} ${finalBuiltTag}
-        docker inspect ${finalBuiltTag}
     """
 }
 

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -40,8 +40,8 @@ pipeline {
                         sh "echo '' > content_sets.yaml"
                     }
 
-                    prepareForDockerMultiplatformBuild()
-                    startLocalRegistry()
+                    cloud.prepareForDockerMultiplatformBuild()
+                    cloud.startLocalRegistry()
                 }
             }
         }
@@ -182,7 +182,7 @@ void buildImage(String imageName) {
 
     // Build multiplatform from generated Dockerfile
     dir('target/image') {
-        dockerBuildMultiPlatform(getTempBuiltImageTag(imageName))
+        cloud.dockerBuildMultiPlatform(getTempBuiltImageTag(imageName))
     }
 }
 

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         CONTAINER_ENGINE='docker'
         CONTAINER_ENGINE_TLS_OPTIONS=''
 
-        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64' // TODO export to DSL ?
+        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64'
     }
     stages {
         stage('Initialization') {
@@ -183,20 +183,19 @@ void buildImage(String imageName) {
     runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
 
     // Build multiplatform from generated Dockerfile
-    String finalBuiltTag = getFullBuiltImageTag(imageName)
     dir('target/image') {
-        // Use local registry
-        String internalRegistryImage = "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
-        dockerBuildMultiPlatform(internalRegistryImage)
-        // Pull and tag to final image
-        sh """
-            docker pull ${internalRegistryImage}
-            docker tag ${internalRegistryImage} ${finalBuiltTag}
-        """
+        dockerBuildMultiPlatform(getTempBuiltImageTag(imageName))
     }
 }
 
 void testImage(String imageName) {
+    String testImageTag = "quay.io/kiegroup/${imageName}:${getImageVersion()}"
+    String tempBuiltImageTag = getTempBuiltImageTag(imageName)
+    // Pull and tag to test image
+    sh """
+        docker pull ${tempBuiltImageTag}
+        docker tag ${tempBuiltImageTag} ${testImageTag}
+    """
     runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_build=true ignore_test_prepare=true ignore_tag=${isProdCI()}")
 }
 
@@ -253,8 +252,8 @@ boolean isProdCI() {
     return env.PROD_CI ? env.PROD_CI.toBoolean() : false
 }
 
-String getFullBuiltImageTag(String imageName) {
-    return "quay.io/kiegroup/${imageName}:${getImageVersion()}"
+String getTempBuiltImageTag(String imageName) {
+    return "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -255,10 +255,7 @@ String getTempBuiltImageTag(String imageName) {
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
-    return sh(returnStdout: stdout, script: """
-source ~/virtenvs/cekit/bin/activate 
-${cmd}
-""")
+    return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
 }
 
 void prepareForDockerMultiplatformBuild(boolean debug = false) {

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -21,8 +21,11 @@ pipeline {
         CI = true
 
         // Linked to node label
+        // Use docker due to multiplatform build
         CONTAINER_ENGINE='docker'
         CONTAINER_ENGINE_TLS_OPTIONS=''
+
+        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64' // TODO export to DSL ?
     }
     stages {
         stage('Initialization') {
@@ -36,6 +39,8 @@ pipeline {
                         // Prod fix to be able to build the image as a community one
                         sh "echo '' > content_sets.yaml"
                     }
+
+                    assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
                 }
             }
         }
@@ -149,15 +154,12 @@ pipeline {
 
 void clean() {
     cleanWorkspaces()
-    cleanImages()
+    util.cleanContainersAndImages(env.CONTAINER_ENGINE)
+    
+    cleanDockerMultiplatformBuild()
 
     // Clean Cekit cache, in case we reuse an old node
     sh "rm -rf \$HOME/.cekit/cache"
-}
-
-void cleanImages() {
-    sh "docker rm -f \$(docker ps -a -q) || date"
-    sh "docker rmi -f \$(docker images -q) || date"
 }
 
 void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
@@ -173,7 +175,25 @@ void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
 }
 
 void buildImage(String imageName) {
-    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=${isProdCI()}")
+    // Generate the Dockerfile
+    runPythonCommand("make build-image cekit_option='--work-dir .' ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
+
+    // Build multiplatform from generated Dockerfile
+    dir('target/image') {
+        // TODO default values in env ?
+        String finalImageName = "quay.io/kiegroup/${imageName}"
+        String finalImageTag = "latest"
+        
+        // Build image locally in tgz file
+        sh """
+            docker buildx build -o type=oci,dest=img-temp.tgz --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${finalImageName}:${finalImageTag} .
+        """
+        String imgSha256 = sh(returnStdout: true, script: "docker import img-temp.tgz").trim()
+        echo "Import result = ${imgSha256}"
+        sh 'docker images' // Debug
+        sh "docker tag ${imgSha256} ${finalImageName}:${finalImageTag}"
+        sh "docker inspect ${finalImageName}:${finalImageTag}"
+    }
 }
 
 void testImage(String imageName) {
@@ -181,7 +201,7 @@ void testImage(String imageName) {
 }
 
 String getMakeBuildImageArgs() {
-    List args = [ "cekit_option='--work-dir .'" ]
+    List args = []
     args.add("KOGITO_APPS_TARGET_BRANCH=${changeTarget}")
     args.add("BUILD_ENGINE=${CONTAINER_ENGINE}")
     if (env.CONTAINER_ENGINE_TLS_OPTIONS) {
@@ -234,4 +254,37 @@ void runPythonCommand(String cmd, boolean stdout = false) {
 source ~/virtenvs/cekit/bin/activate 
 ${cmd}
 """)
+}
+
+List getBuildPlatforms() {
+    return env.BUILD_IMAGE_PLATFORMS?.split(',')
+}
+
+void prepareForDockerMultiplatformBuild(boolean debug = false) {
+    sh 'docker run --rm --privileged docker.io/tonistiigi/binfmt --install all'
+    
+    // Debug purpose
+    if (debug) {
+        sh 'docker context ls'
+        sh 'docker buildx ls'
+    }
+    
+    writeFile(file: 'buildkitd.toml', text: '''
+debug = true
+[registry."docker.io"]
+mirrors = ["mirror.gcr.io"]
+        ''')
+    
+    sh 'docker buildx rm mybuilder || true'
+    sh 'docker buildx create --name mybuilder --driver docker-container --bootstrap --config ${WORKSPACE}/buildkitd.toml'
+    sh 'docker buildx use mybuilder'
+    
+    if (debug) {
+        sh 'docker buildx inspect'
+        sh 'docker buildx ls'
+    }
+}
+
+void cleanDockerMultiplatformBuild() {
+    sh 'docker buildx rm mybuilder || true'
 }

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         CONTAINER_ENGINE='docker'
         CONTAINER_ENGINE_TLS_OPTIONS=''
 
-        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64'
+        IMAGE_BUILD_PLATFORMS = 'linux/amd64,linux/arm64'
     }
     stages {
         stage('Initialization') {
@@ -294,7 +294,7 @@ http = true
 void dockerBuildMultiPlatform(String buildImageTag) {
     // Build image locally in tgz file
     sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${BUILD_IMAGE_PLATFORMS} -t ${buildImageTag} .
+        docker buildx build --push --sbom=false --provenance=false --platform ${IMAGE_BUILD_PLATFORMS} -t ${buildImageTag} .
         docker buildx imagetools inspect ${buildImageTag}
     """
 }

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -182,7 +182,7 @@ void buildImage(String imageName) {
 
     // Build multiplatform from generated Dockerfile
     dir('target/image') {
-        cloud.dockerBuildMultiPlatform(getTempBuiltImageTag(imageName))
+        cloud.dockerBuildMultiPlatformImages(getTempBuiltImageTag(imageName), getImageBuildPlatforms(), false)
     }
 }
 
@@ -240,6 +240,10 @@ String[] getImages() {
         listCmd += ' arg=--prod'
     }
     return runPythonCommand("${listCmd} | tr '\\n' ','", true).trim().split(',')
+}
+
+List getImageBuildPlatforms() {
+    return "${IMAGE_BUILD_PLATFORMS}".split(',') as List
 }
 
 String getImageVersion() {

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -180,7 +180,7 @@ void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
 
 void buildImage(String imageName) {
     // Generate the Dockerfile
-    runPythonCommand("make build-image cekit_option='--work-dir .' ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
+    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
 
     // Build multiplatform from generated Dockerfile
     String finalBuiltTag = getFullBuiltImageTag(imageName)
@@ -201,7 +201,7 @@ void testImage(String imageName) {
 }
 
 String getMakeBuildImageArgs() {
-    List args = []
+    List args = [ "cekit_option='--work-dir .'" ]
     args.add("KOGITO_APPS_TARGET_BRANCH=${changeTarget}")
     args.add("BUILD_ENGINE=${CONTAINER_ENGINE}")
     if (env.CONTAINER_ENGINE_TLS_OPTIONS) {

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -41,6 +41,8 @@ pipeline {
                     }
 
                     assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
+
+                    prepareForDockerMultiplatformBuild()
                 }
             }
         }
@@ -154,7 +156,7 @@ pipeline {
 
 void clean() {
     cleanWorkspaces()
-    util.cleanContainersAndImages(env.CONTAINER_ENGINE)
+    util.cleanNode(env.CONTAINER_ENGINE)
     
     cleanDockerMultiplatformBuild()
 
@@ -179,20 +181,9 @@ void buildImage(String imageName) {
     runPythonCommand("make build-image cekit_option='--work-dir .' ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
 
     // Build multiplatform from generated Dockerfile
-    dir('target/image') {
-        // TODO default values in env ?
-        String finalImageName = "quay.io/kiegroup/${imageName}"
-        String finalImageTag = "latest"
-        
-        // Build image locally in tgz file
-        sh """
-            docker buildx build -o type=oci,dest=img-temp.tgz --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${finalImageName}:${finalImageTag} .
-        """
-        String imgSha256 = sh(returnStdout: true, script: "docker import img-temp.tgz").trim()
-        echo "Import result = ${imgSha256}"
-        sh 'docker images' // Debug
-        sh "docker tag ${imgSha256} ${finalImageName}:${finalImageTag}"
-        sh "docker inspect ${finalImageName}:${finalImageTag}"
+    String finalBuiltTag = getFullBuiltImageTag(imageName)
+    dir('target/image') {        
+        dockerBuildMultiPlatform(imageName, finalBuiltTag)
     }
 }
 
@@ -245,8 +236,16 @@ String[] getImages() {
     return runPythonCommand("${listCmd} | tr '\\n' ','", true).trim().split(',')
 }
 
+String getImageVersion() {
+    return runPythonCommand('make display-image-version', true).trim()
+}
+
 boolean isProdCI() {
     return env.PROD_CI ? env.PROD_CI.toBoolean() : false
+}
+
+String getFullBuiltImageTag(String imageName) {
+    return "quay.io/kiegroup/${imageName}:${getImageVersion()}"
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
@@ -261,7 +260,10 @@ List getBuildPlatforms() {
 }
 
 void prepareForDockerMultiplatformBuild(boolean debug = false) {
-    sh 'docker run --rm --privileged docker.io/tonistiigi/binfmt --install all'
+    // For multiplatform build
+    sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
+    // For pushing built images
+    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
     
     // Debug purpose
     if (debug) {
@@ -285,6 +287,20 @@ mirrors = ["mirror.gcr.io"]
     }
 }
 
+void dockerBuildMultiPlatform(String imageName, String finalBuiltTag) {
+    // Build image locally in tgz file
+    String internalRegistryImage = "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
+    sh """
+        docker buildx build --push --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${internalRegistryImage} .
+        docker buildx imagetools inspect ${internalRegistryImage}
+        docker pull ${internalRegistryImage}
+        docker tag ${internalRegistryImage} ${finalBuiltTag}
+        docker inspect ${finalBuiltTag}
+    """
+}
+
 void cleanDockerMultiplatformBuild() {
     sh 'docker buildx rm mybuilder || true'
+    sh 'docker kill binfmt || true'
+    sh 'docker kill registry || true'
 }

--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -40,8 +40,6 @@ pipeline {
                         sh "echo '' > content_sets.yaml"
                     }
 
-                    assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
-
                     prepareForDockerMultiplatformBuild()
                     startLocalRegistry()
                 }
@@ -263,10 +261,6 @@ ${cmd}
 """)
 }
 
-List getBuildPlatforms() {
-    return env.BUILD_IMAGE_PLATFORMS?.split(',')
-}
-
 void prepareForDockerMultiplatformBuild(boolean debug = false) {
     // For multiplatform build
     sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
@@ -300,7 +294,7 @@ http = true
 void dockerBuildMultiPlatform(String buildImageTag) {
     // Build image locally in tgz file
     sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${buildImageTag} .
+        docker buildx build --push --sbom=false --provenance=false --platform ${BUILD_IMAGE_PLATFORMS} -t ${buildImageTag} .
         docker buildx imagetools inspect ${buildImageTag}
     """
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -45,7 +45,7 @@ pipeline {
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
 
-        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64'
+        IMAGE_BUILD_PLATFORMS = 'linux/amd64,linux/arm64'
     }
 
     stages {
@@ -396,8 +396,10 @@ void buildImage(String imageName) {
     runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
 
     // Build multiplatform from generated Dockerfile
+    String tempBuiltImageTag = getTempBuiltImageTag(imageName)
+    String squashMessage = "${imageName}:${getImageVersion()} squashed"
     dir('target/image') {
-        dockerBuildMultiPlatform(getTempBuiltImageTag(imageName))
+        dockerBuildMultiPlatform(tempBuiltImageTag, true, squashMessage)
     }
 }
 
@@ -670,6 +672,10 @@ boolean shouldSkipTests() {
     return params.SKIP_TESTS
 }
 
+List getImageBuildPlatforms() {
+    return "${IMAGE_BUILD_PLATFORMS}".split(',')
+}
+
 void setDeployPropertyIfNeeded(String key, def value) {
     if (value) {
         deployProperties[key] = value
@@ -685,7 +691,7 @@ boolean isThereAnyChanges() {
 }
 
 String getTempBuiltImageTag(String imageName) {
-    return "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
+    return "localhost:5000/${imageName}:${getImageVersion()}"
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
@@ -696,6 +702,8 @@ ${cmd}
 }
 
 void prepareForDockerMultiplatformBuild(boolean debug = false) {
+    cleanDockerMultiplatformBuild()
+
     // For multiplatform build
     sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
 
@@ -714,7 +722,6 @@ mirrors = ["mirror.gcr.io"]
 http = true
         ''')
 
-    sh 'docker buildx rm mybuilder || true'
     sh 'docker buildx create --name mybuilder --driver docker-container --driver-opt network=host --bootstrap --config ${WORKSPACE}/buildkitd.toml'
     sh 'docker buildx use mybuilder'
 
@@ -725,46 +732,91 @@ http = true
     }
 }
 
-void dockerBuildMultiPlatform(String buildImageTag) {
+void dockerBuildMultiPlatform(String buildImageTag, boolean squashImages = true, String squashMessage = "Squashed ${buildImageTag}") {
     // Build image locally in tgz file
-    "${BUILD_IMAGE_PLATFORMS}".split(',').each { platform ->
+    List buildPlatformImages = getImageBuildPlatforms().collect { platform ->
         String os_arch = platform.replaceAll('/', '-')
         String platformImage = "${buildImageTag}-${os_arch}"
-        sh """
-            docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${platformImage} .
-            docker buildx imagetools inspect ${platformImage}
-            docker pull --platform ${platform} -t ${platformImage}
-        """
+        String finalPlatformImage = platformImage
+
+        // Build
+        dockerBuildPlatformImage(platformImage, platform)
+
+        if (squashImages) {
+            finalPlatformImage = dockerSquashImage(platformImage, squashMessage)
+        }
+
+        return finalPlatformImage
     }
-    List architectures = "${BUILD_IMAGE_PLATFORMS}".collect { it.replaceAll('/', '-') }
-    String dockerManifestCmd = "docker manifest create ${buildImageTag}"
-    architectures.each {
-        dockerManifestCmd += " --amend ${buildImageTag}-${it}"
-    }
+
+    dockerCreateManifest(buildImageTag, buildPlatformImages)
+}
+
+void dockerBuildPlatformImage(String buildImageTag, String platform) {
     sh """
-        ${dockerManifestCmd}
+        docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} .
+        docker buildx imagetools inspect ${buildImageTag}
+        docker pull --platform ${platform} ${buildImageTag}
+    """
+}
+
+void dockerCreateManifest(String buildImageTag, List manifestImages) {
+    // Create multiplatform manifest
+    sh """
+        docker manifest rm ${buildImageTag} || true
+        docker manifest create ${buildImageTag} --insecure ${manifestImages.join(' ')}
         docker manifest push ${buildImageTag}
     """
 }
 
+void debugImage(String imageTag) {
+    sh """
+        docker images
+        docker history ${imageTag}
+        docker inspect ${imageTag}
+    """
+}
+
+void dockerSquashImage(String baseImage, String squashMessage) {
+    String squashedPlatformImage = "${baseImage}"
+
+    // Squash images
+    def nbLayers = Integer.parseInt(sh(returnStdout: true, script: "docker history ${baseImage} | grep buildkit.dockerfile | wc -l").trim())
+    nbLayers++ // Get the next layer not done by buildkit
+    echo "Got ${nbLayers} layers to squash"
+    // Use message option in docker-squash due to https://github.com/goldmann/docker-squash/issues/220
+    runPythonCommand("""
+        docker-squash -v -m '${squashMessage}' -f ${nbLayers} -t ${squashedPlatformImage} ${baseImage} 
+        docker push ${squashedPlatformImage}
+    """)
+
+    return squashedPlatformImage
+}
+
 void cleanDockerMultiplatformBuild() {
     sh 'docker buildx rm mybuilder || true'
-    sh 'docker kill binfmt || true'
+    sh 'docker rm -f binfmt || true'
+    sh 'docker buildx ls'
+    sh 'docker ps'
 }
 
 void startLocalRegistry() {
+    cleanLocalRegistry()
     sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
+    sh 'docker ps'
 }
 
 void cleanLocalRegistry() {
-    sh 'docker kill registry || true'
+    sh 'docker rm -f registry || true'
+    sh 'docker ps'
 }
 
 void installSkopeo() {
-    sh """
+    cleanSkopeo()
+    sh '''
         sudo yum -y install --nobest skopeo
         skopeo --version
-    """
+    '''
 }
 
 void cleanSkopeo() {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -482,12 +482,7 @@ void copyToFinalImages() {
 }
 
 void copyToFinalImage(String oldImageName, String newImageName) {
-    retry(env.MAX_REGISTRY_RETRIES) {
-        sh """
-            skopeo inspect --tls-verify=false docker://${oldImageName}
-            skopeo copy --tls-verify=false --all docker://${oldImageName} docker://${newImageName}
-        """
-    }
+    cloud.skopeoCopyRegistryImages(oldImageName, newImageName, env.MAX_REGISTRY_RETRIES)
 }
 
 // Set images public on quay. Useful when new images are introduced.

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -727,9 +727,23 @@ http = true
 
 void dockerBuildMultiPlatform(String buildImageTag) {
     // Build image locally in tgz file
+    "${BUILD_IMAGE_PLATFORMS}".split(',').each { platform ->
+        String os_arch = platform.replaceAll('/', '-')
+        String platformImage = "${buildImageTag}-${os_arch}"
+        sh """
+            docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${platformImage} .
+            docker buildx imagetools inspect ${platformImage}
+            docker pull --platform ${platform} -t ${platformImage}
+        """
+    }
+    List architectures = "${BUILD_IMAGE_PLATFORMS}".collect { it.replaceAll('/', '-') }
+    String dockerManifestCmd = "docker manifest create ${buildImageTag}"
+    architectures.each {
+        dockerManifestCmd += " --amend ${buildImageTag}-${it}"
+    }
     sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${BUILD_IMAGE_PLATFORMS} -t ${buildImageTag} .
-        docker buildx imagetools inspect ${buildImageTag}
+        ${dockerManifestCmd}
+        docker manifest push ${buildImageTag}
     """
 }
 

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -35,14 +35,17 @@ pipeline {
         JAVA_HOME = "${GRAALVM_HOME}"
 
         // Linked to node label
-        CONTAINER_ENGINE='docker'
-        CONTAINER_ENGINE_TLS_OPTIONS=''
+        // Use docker due to multiplatform build
+        CONTAINER_ENGINE = 'docker'
+        CONTAINER_ENGINE_TLS_OPTIONS = ''
 
         OPENSHIFT_API = credentials('OPENSHIFT_API')
         OPENSHIFT_REGISTRY = credentials('OPENSHIFT_REGISTRY')
         OPENSHIFT_CREDS_KEY = 'OPENSHIFT_CREDS'
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
+
+        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64' // TODO export to DSL ?
     }
 
     stages {
@@ -62,6 +65,16 @@ pipeline {
                         assert getProjectVersion()
                         assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
+
+                    // Login to final registry
+                    if (isDeployImageInOpenshiftRegistry()) {
+                        loginOpenshiftRegistry()
+                    } else if (getDeployImageRegistryCredentials()) {
+                        loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials())
+                    }
+
+                    assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
+                    prepareForDockerMultiplatformBuild()
                 }
             }
             post {
@@ -247,11 +260,6 @@ pipeline {
         stage('Pushing') {
             steps {
                 script {
-                    if (isDeployImageInOpenshiftRegistry()) {
-                        loginOpenshiftRegistry()
-                    } else if (getDeployImageRegistryCredentials()) {
-                        loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials())
-                    }
                     pushImages()
 
                     if (isQuayRegistry()) {
@@ -379,18 +387,30 @@ void commitChanges(String commitMsg) {
 
 void clean() {
     cleanWs()
-    cleanImages()
+    util.cleanNode(env.CONTAINER_ENGINE)
+
+    cleanDockerMultiplatformBuild()
 
     // Clean Cekit cache, in case we reuse an old node
     sh 'rm -rf \$HOME/.cekit/cache'
 }
 
-void cleanImages() {
-    sh "${env.CONTAINER_ENGINE} rm -f \$(${env.CONTAINER_ENGINE} ps -a -q) || date"
-    sh "${env.CONTAINER_ENGINE} rmi -f \$(${env.CONTAINER_ENGINE} images -q) || date"
-}
-
 void buildImage(String imageName) {
+    // Generate the Dockerfile
+    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
+
+    // Build multiplatform from generated Dockerfile
+    String finalBuiltTag = getFullBuiltImageTag(imageName)
+    dir('target/image') {
+        String tempImageTag = getTempBuiltImageTag(imageName)
+        dockerBuildMultiPlatform(tempImageTag)
+        // Pull and tag to final image
+        sh """
+            docker pull ${tempImageTag}
+            docker tag ${tempImageTag} ${finalBuiltTag}
+        """
+    }
+
     runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true")
 }
 
@@ -406,7 +426,7 @@ String getMakeBuildImageArgs() {
     }
     args.add("BUILD_ENGINE=${CONTAINER_ENGINE}")
     if (env.CONTAINER_ENGINE_TLS_OPTIONS) {
-        args.add("BUILD_ENGINE_TLS_OPTIONS=${CONTAINER_ENGINE_TLS_OPTIONS}")   
+        args.add("BUILD_ENGINE_TLS_OPTIONS=${CONTAINER_ENGINE_TLS_OPTIONS}")
     }
     return args.join(' ')
 }
@@ -453,7 +473,7 @@ List getTestFailedImages() {
 
 void tagImages() {
     for (String imageName : getBuiltImages()) {
-        String builtImageFullTag = "quay.io/kiegroup/${imageName}:${getImageVersion()}"
+        String builtImageFullTag = getFullBuiltImageTag()
         tagImage(builtImageFullTag, buildImageName(imageName))
         if (isDeployLatestTag()) {
             tagImage(builtImageFullTag, buildImageName(imageName, 'latest'))
@@ -511,7 +531,7 @@ String getFinalImageName(String imageName) {
 }
 
 String getImageVersion() {
-    return sh(returnStdout: true, script: 'make display-image-version').trim()
+    return runPythonCommand('make display-image-version', true).trim()
 }
 
 String getReducedTag() {
@@ -684,9 +704,72 @@ boolean isThereAnyChanges() {
     return sh(script: 'git status --porcelain', returnStdout: true).trim() != ''
 }
 
+String getTempBuiltImageTag(String imageName) {
+    return "${getDeployImageRegistry()}/${getDeployImageNamespace()}/${imageName}-nightly:${githubscm.getCommitHash()}"
+}
+
+String getFullBuiltImageTag(String imageName) {
+    return "quay.io/kiegroup/${imageName}:${getImageVersion()}"
+}
+
 void runPythonCommand(String cmd, boolean stdout = false) {
     return sh(returnStdout: stdout, script: """
-source ~/virtenvs/cekit/bin/activate 
+source ~/virtenvs/cekit/bin/activate
 ${cmd}
 """)
+}
+
+List getBuildPlatforms() {
+    return env.BUILD_IMAGE_PLATFORMS?.split(',')
+}
+
+void prepareForDockerMultiplatformBuild(boolean debug = false) {
+    // For multiplatform build
+    sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
+
+    // Debug purpose
+    if (debug) {
+        sh 'docker context ls'
+        sh 'docker buildx ls'
+        sh 'docker ps'
+    }
+
+    writeFile(file: 'buildkitd.toml', text: '''
+debug = true
+[registry."docker.io"]
+mirrors = ["mirror.gcr.io"]
+[registry."localhost:5000"]
+http = true
+        ''')
+
+    sh 'docker buildx rm mybuilder || true'
+    sh 'docker buildx create --name mybuilder --driver docker-container --driver-opt network=host --bootstrap --config ${WORKSPACE}/buildkitd.toml'
+    sh 'docker buildx use mybuilder'
+
+    if (debug) {
+        sh 'docker buildx inspect'
+        sh 'docker buildx ls'
+        sh 'docker ps'
+    }
+}
+
+void dockerBuildMultiPlatform(String buildImageTag) {
+    // Build image locally in tgz file
+    sh """
+        docker buildx build --push --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${buildImageTag} .
+        docker buildx imagetools inspect ${buildImageTag}
+    """
+}
+
+void startLocalRegistry() {
+    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
+}
+
+void cleanLocalRegistry() {
+    sh 'docker kill registry || true'
+}
+
+void cleanDockerMultiplatformBuild() {
+    sh 'docker buildx rm mybuilder || true'
+    sh 'docker kill binfmt || true'
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -695,10 +695,7 @@ String getTempBuiltImageTag(String imageName) {
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
-    return sh(returnStdout: stdout, script: """
-source ~/virtenvs/cekit/bin/activate
-${cmd}
-""")
+    return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
 }
 
 void prepareForDockerMultiplatformBuild(boolean debug = false) {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -75,6 +75,7 @@ pipeline {
 
                     assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
                     prepareForDockerMultiplatformBuild()
+                    installSkopeo() // TODO should be installed directly on the node
                 }
             }
             post {
@@ -250,17 +251,10 @@ pipeline {
                 }
             }
         }
-        stage('Tagging') {
+        stage('Copy to final image') {
             steps {
                 script {
-                    tagImages()
-                }
-            }
-        }
-        stage('Pushing') {
-            steps {
-                script {
-                    pushImages()
+                    copyToFinalImages()
 
                     if (isQuayRegistry()) {
                         makeQuayImagesPublic()
@@ -390,6 +384,7 @@ void clean() {
     util.cleanNode(env.CONTAINER_ENGINE)
 
     cleanDockerMultiplatformBuild()
+    cleanSkopeo()
 
     // Clean Cekit cache, in case we reuse an old node
     sh 'rm -rf \$HOME/.cekit/cache'
@@ -400,21 +395,20 @@ void buildImage(String imageName) {
     runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
 
     // Build multiplatform from generated Dockerfile
-    String finalBuiltTag = getFullBuiltImageTag(imageName)
     dir('target/image') {
         String tempImageTag = getTempBuiltImageTag(imageName)
         dockerBuildMultiPlatform(tempImageTag)
-        // Pull and tag to final image
-        sh """
-            docker pull ${tempImageTag}
-            docker tag ${tempImageTag} ${finalBuiltTag}
-        """
     }
-
-    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true")
 }
 
 void testImage(String imageName) {
+    String testImageTag = "quay.io/kiegroup/${imageName}:${getImageVersion()}"
+    String tempBuiltImageTag = getTempBuiltImageTag(imageName)
+    // Pull and tag to test image
+    sh """
+        docker pull ${tempBuiltImageTag}
+        docker tag ${tempBuiltImageTag} ${testImageTag}
+    """
     runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_build=true ignore_test_prepare=true")
 }
 
@@ -471,40 +465,26 @@ List getTestFailedImages() {
     return TEST_FAILED_IMAGES
 }
 
-void tagImages() {
+void copyToFinalImages() {
     for (String imageName : getBuiltImages()) {
-        String builtImageFullTag = getFullBuiltImageTag()
-        tagImage(builtImageFullTag, buildImageName(imageName))
+        String tempBuiltImageTag = getTempBuiltImageTag(imageName)
+        copyToFinalImage(tempBuiltImageTag, buildImageName(imageName))
         if (isDeployLatestTag()) {
-            tagImage(builtImageFullTag, buildImageName(imageName, 'latest'))
+            copyToFinalImage(tempBuiltImageTag, buildImageName(imageName, 'latest'))
         }
         String reducedTag = getReducedTag()
         if (reducedTag) {
-            tagImage(builtImageFullTag, buildImageName(imageName, reducedTag))
+            copyToFinalImage(tempBuiltImageTag, buildImageName(imageName, reducedTag))
         }
     }
 }
 
-void tagImage(String oldImageName, String newImageName) {
-    sh "${env.CONTAINER_ENGINE} tag ${oldImageName} ${newImageName}"
-}
-
-void pushImages() {
-    for (String imageName : getBuiltImages()) {
-        pushImage(buildImageName(imageName))
-        if (isDeployLatestTag()) {
-            pushImage(buildImageName(imageName, 'latest'))
-        }
-        String reducedTag = getReducedTag()
-        if (reducedTag) {
-            pushImage(buildImageName(imageName, reducedTag))
-        }
-    }
-}
-
-void pushImage(String fullImageName) {
+void copyToFinalImage(String oldImageName, String newImageName) {
     retry(env.MAX_REGISTRY_RETRIES) {
-        sh "${env.CONTAINER_ENGINE} push ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${fullImageName}"
+        sh """
+            skopeo inspect docker://${oldImageName}
+            skopeo copy --all docker://${oldImageName} docker://${newImageName}
+        """
     }
 }
 
@@ -708,10 +688,6 @@ String getTempBuiltImageTag(String imageName) {
     return "${getDeployImageRegistry()}/${getDeployImageNamespace()}/${imageName}-nightly:${githubscm.getCommitHash()}"
 }
 
-String getFullBuiltImageTag(String imageName) {
-    return "quay.io/kiegroup/${imageName}:${getImageVersion()}"
-}
-
 void runPythonCommand(String cmd, boolean stdout = false) {
     return sh(returnStdout: stdout, script: """
 source ~/virtenvs/cekit/bin/activate
@@ -761,15 +737,18 @@ void dockerBuildMultiPlatform(String buildImageTag) {
     """
 }
 
-void startLocalRegistry() {
-    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
-}
-
-void cleanLocalRegistry() {
-    sh 'docker kill registry || true'
-}
-
 void cleanDockerMultiplatformBuild() {
     sh 'docker buildx rm mybuilder || true'
     sh 'docker kill binfmt || true'
+}
+
+void installSkopeo() {
+    sh """
+        sudo yum -y install --nobest skopeo
+        skopeo --version
+    """
+}
+
+void cleanSkopeo() {
+    sh 'sudo yum -y remove skopeo || true'
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -383,9 +383,9 @@ void clean() {
     cleanWs()
     util.cleanNode(env.CONTAINER_ENGINE)
 
-    cleanDockerMultiplatformBuild()
-    cleanLocalRegistry()
-    cleanSkopeo()
+    cloud.cleanDockerMultiplatformBuild()
+    cloud.cleanLocalRegistry()
+    cloud.cleanSkopeo()
 
     // Clean Cekit cache, in case we reuse an old node
     sh 'rm -rf \$HOME/.cekit/cache'

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -73,9 +73,9 @@ pipeline {
                         loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials())
                     }
 
-                    prepareForDockerMultiplatformBuild()
-                    startLocalRegistry()
-                    installSkopeo()
+                    cloud.prepareForDockerMultiplatformBuild()
+                    cloud.startLocalRegistry()
+                    cloud.installSkopeo()
                 }
             }
             post {
@@ -399,7 +399,7 @@ void buildImage(String imageName) {
     String tempBuiltImageTag = getTempBuiltImageTag(imageName)
     String squashMessage = "${imageName}:${getImageVersion()} squashed"
     dir('target/image') {
-        dockerBuildMultiPlatform(tempBuiltImageTag, true, squashMessage)
+        cloud.dockerBuildMultiPlatformImages(tempBuiltImageTag, true, squashMessage)
     }
 }
 
@@ -696,126 +696,4 @@ String getTempBuiltImageTag(String imageName) {
 
 void runPythonCommand(String cmd, boolean stdout = false) {
     return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
-}
-
-void prepareForDockerMultiplatformBuild(boolean debug = false) {
-    cleanDockerMultiplatformBuild()
-
-    // For multiplatform build
-    sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
-
-    // Debug purpose
-    if (debug) {
-        sh 'docker context ls'
-        sh 'docker buildx ls'
-        sh 'docker ps'
-    }
-
-    writeFile(file: 'buildkitd.toml', text: '''
-debug = true
-[registry."docker.io"]
-mirrors = ["mirror.gcr.io"]
-[registry."localhost:5000"]
-http = true
-        ''')
-
-    sh 'docker buildx create --name mybuilder --driver docker-container --driver-opt network=host --bootstrap --config ${WORKSPACE}/buildkitd.toml'
-    sh 'docker buildx use mybuilder'
-
-    if (debug) {
-        sh 'docker buildx inspect'
-        sh 'docker buildx ls'
-        sh 'docker ps'
-    }
-}
-
-void dockerBuildMultiPlatform(String buildImageTag, boolean squashImages = true, String squashMessage = "Squashed ${buildImageTag}") {
-    // Build image locally in tgz file
-    List buildPlatformImages = getImageBuildPlatforms().collect { platform ->
-        String os_arch = platform.replaceAll('/', '-')
-        String platformImage = "${buildImageTag}-${os_arch}"
-        String finalPlatformImage = platformImage
-
-        // Build
-        dockerBuildPlatformImage(platformImage, platform)
-
-        if (squashImages) {
-            finalPlatformImage = dockerSquashImage(platformImage, squashMessage)
-        }
-
-        return finalPlatformImage
-    }
-
-    dockerCreateManifest(buildImageTag, buildPlatformImages)
-}
-
-void dockerBuildPlatformImage(String buildImageTag, String platform) {
-    sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} .
-        docker buildx imagetools inspect ${buildImageTag}
-        docker pull --platform ${platform} ${buildImageTag}
-    """
-}
-
-void dockerCreateManifest(String buildImageTag, List manifestImages) {
-    // Create multiplatform manifest
-    sh """
-        docker manifest rm ${buildImageTag} || true
-        docker manifest create ${buildImageTag} --insecure ${manifestImages.join(' ')}
-        docker manifest push ${buildImageTag}
-    """
-}
-
-void debugImage(String imageTag) {
-    sh """
-        docker images
-        docker history ${imageTag}
-        docker inspect ${imageTag}
-    """
-}
-
-void dockerSquashImage(String baseImage, String squashMessage) {
-    String squashedPlatformImage = "${baseImage}"
-
-    // Squash images
-    def nbLayers = Integer.parseInt(sh(returnStdout: true, script: "docker history ${baseImage} | grep buildkit.dockerfile | wc -l").trim())
-    nbLayers++ // Get the next layer not done by buildkit
-    echo "Got ${nbLayers} layers to squash"
-    // Use message option in docker-squash due to https://github.com/goldmann/docker-squash/issues/220
-    runPythonCommand("""
-        docker-squash -v -m '${squashMessage}' -f ${nbLayers} -t ${squashedPlatformImage} ${baseImage} 
-        docker push ${squashedPlatformImage}
-    """)
-
-    return squashedPlatformImage
-}
-
-void cleanDockerMultiplatformBuild() {
-    sh 'docker buildx rm mybuilder || true'
-    sh 'docker rm -f binfmt || true'
-    sh 'docker buildx ls'
-    sh 'docker ps'
-}
-
-void startLocalRegistry() {
-    cleanLocalRegistry()
-    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
-    sh 'docker ps'
-}
-
-void cleanLocalRegistry() {
-    sh 'docker rm -f registry || true'
-    sh 'docker ps'
-}
-
-void installSkopeo() {
-    cleanSkopeo()
-    sh '''
-        sudo yum -y install --nobest skopeo
-        skopeo --version
-    '''
-}
-
-void cleanSkopeo() {
-    sh 'sudo yum -y remove skopeo || true'
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -251,10 +251,10 @@ pipeline {
                 }
             }
         }
-        stage('Copy to final image') {
+        stage('Push to registry') {
             steps {
                 script {
-                    copyToFinalImages()
+                    pushFinalImages()
 
                     if (isQuayRegistry()) {
                         makeQuayImagesPublic()
@@ -467,21 +467,21 @@ List getTestFailedImages() {
     return TEST_FAILED_IMAGES
 }
 
-void copyToFinalImages() {
+void pushFinalImages() {
     for (String imageName : getBuiltImages()) {
         String tempBuiltImageTag = getTempBuiltImageTag(imageName)
-        copyToFinalImage(tempBuiltImageTag, buildImageName(imageName))
+        pushFinalImage(tempBuiltImageTag, buildImageName(imageName))
         if (isDeployLatestTag()) {
-            copyToFinalImage(tempBuiltImageTag, buildImageName(imageName, 'latest'))
+            pushFinalImage(tempBuiltImageTag, buildImageName(imageName, 'latest'))
         }
         String reducedTag = getReducedTag()
         if (reducedTag) {
-            copyToFinalImage(tempBuiltImageTag, buildImageName(imageName, reducedTag))
+            pushFinalImage(tempBuiltImageTag, buildImageName(imageName, reducedTag))
         }
     }
 }
 
-void copyToFinalImage(String oldImageName, String newImageName) {
+void pushFinalImage(String oldImageName, String newImageName) {
     cloud.skopeoCopyRegistryImages(oldImageName, newImageName, Integer.parseInt(env.MAX_REGISTRY_RETRIES))
 }
 

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -73,10 +73,9 @@ pipeline {
                         loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials())
                     }
 
-                    assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
                     prepareForDockerMultiplatformBuild()
                     startLocalRegistry()
-                    installSkopeo() // TODO should be installed directly on the node
+                    installSkopeo()
                 }
             }
             post {
@@ -696,10 +695,6 @@ ${cmd}
 """)
 }
 
-List getBuildPlatforms() {
-    return env.BUILD_IMAGE_PLATFORMS?.split(',')
-}
-
 void prepareForDockerMultiplatformBuild(boolean debug = false) {
     // For multiplatform build
     sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
@@ -733,7 +728,7 @@ http = true
 void dockerBuildMultiPlatform(String buildImageTag) {
     // Build image locally in tgz file
     sh """
-        docker buildx build --push --sbom=false --provenance=false --platform ${getBuildPlatforms().join(',')} -t ${buildImageTag} .
+        docker buildx build --push --sbom=false --provenance=false --platform ${BUILD_IMAGE_PLATFORMS} -t ${buildImageTag} .
         docker buildx imagetools inspect ${buildImageTag}
     """
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -453,7 +453,7 @@ List getTestFailedImages() {
 
 void tagImages() {
     for (String imageName : getBuiltImages()) {
-        String builtImageFullTag = "quay.io/kiegroup/${imageName}:latest"
+        String builtImageFullTag = "quay.io/kiegroup/${imageName}:${getImageVersion()}"
         tagImage(builtImageFullTag, buildImageName(imageName))
         if (isDeployLatestTag()) {
             tagImage(builtImageFullTag, buildImageName(imageName, 'latest'))
@@ -508,6 +508,10 @@ String buildImageName(String imageName, String imageTag = '') {
 
 String getFinalImageName(String imageName) {
     return getDeployImageNameSuffix() ? "${imageName}-${getDeployImageNameSuffix()}" : imageName
+}
+
+String getImageVersion() {
+    return sh(returnStdout: true, script: 'make display-image-version').trim()
 }
 
 String getReducedTag() {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -399,7 +399,7 @@ void buildImage(String imageName) {
     String tempBuiltImageTag = getTempBuiltImageTag(imageName)
     String squashMessage = "${imageName}:${getImageVersion()} squashed"
     dir('target/image') {
-        cloud.dockerBuildMultiPlatformImages(tempBuiltImageTag, true, squashMessage)
+        cloud.dockerBuildMultiPlatformImages(tempBuiltImageTag, getImageBuildPlatforms(), true, squashMessage)
     }
 }
 
@@ -482,7 +482,7 @@ void copyToFinalImages() {
 }
 
 void copyToFinalImage(String oldImageName, String newImageName) {
-    cloud.skopeoCopyRegistryImages(oldImageName, newImageName, env.MAX_REGISTRY_RETRIES)
+    cloud.skopeoCopyRegistryImages(oldImageName, newImageName, Integer.parseInt(env.MAX_REGISTRY_RETRIES))
 }
 
 // Set images public on quay. Useful when new images are introduced.
@@ -668,7 +668,7 @@ boolean shouldSkipTests() {
 }
 
 List getImageBuildPlatforms() {
-    return "${IMAGE_BUILD_PLATFORMS}".split(',')
+    return "${IMAGE_BUILD_PLATFORMS}".split(',') as List
 }
 
 void setDeployPropertyIfNeeded(String key, def value) {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -45,7 +45,7 @@ pipeline {
 
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
 
-        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64' // TODO export to DSL ?
+        BUILD_IMAGE_PLATFORMS = 'linux/amd64,linux/arm64'
     }
 
     stages {
@@ -75,6 +75,7 @@ pipeline {
 
                     assert getBuildPlatforms(): 'Please provide `BUILD_IMAGE_PLATFORMS` env (example: \'linux/amd64\')'
                     prepareForDockerMultiplatformBuild()
+                    startLocalRegistry()
                     installSkopeo() // TODO should be installed directly on the node
                 }
             }
@@ -384,6 +385,7 @@ void clean() {
     util.cleanNode(env.CONTAINER_ENGINE)
 
     cleanDockerMultiplatformBuild()
+    cleanLocalRegistry()
     cleanSkopeo()
 
     // Clean Cekit cache, in case we reuse an old node
@@ -396,8 +398,7 @@ void buildImage(String imageName) {
 
     // Build multiplatform from generated Dockerfile
     dir('target/image') {
-        String tempImageTag = getTempBuiltImageTag(imageName)
-        dockerBuildMultiPlatform(tempImageTag)
+        dockerBuildMultiPlatform(getTempBuiltImageTag(imageName))
     }
 }
 
@@ -482,8 +483,8 @@ void copyToFinalImages() {
 void copyToFinalImage(String oldImageName, String newImageName) {
     retry(env.MAX_REGISTRY_RETRIES) {
         sh """
-            skopeo inspect docker://${oldImageName}
-            skopeo copy --all docker://${oldImageName} docker://${newImageName}
+            skopeo inspect --tls-verify=false docker://${oldImageName}
+            skopeo copy --tls-verify=false --all docker://${oldImageName} docker://${newImageName}
         """
     }
 }
@@ -685,7 +686,7 @@ boolean isThereAnyChanges() {
 }
 
 String getTempBuiltImageTag(String imageName) {
-    return "${getDeployImageRegistry()}/${getDeployImageNamespace()}/${imageName}-nightly:${githubscm.getCommitHash()}"
+    return "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
@@ -740,6 +741,14 @@ void dockerBuildMultiPlatform(String buildImageTag) {
 void cleanDockerMultiplatformBuild() {
     sh 'docker buildx rm mybuilder || true'
     sh 'docker kill binfmt || true'
+}
+
+void startLocalRegistry() {
+    sh 'docker run -d -p 5000:5000 --restart=always --name registry --name registry registry:2'
+}
+
+void cleanLocalRegistry() {
+    sh 'docker kill registry || true'
 }
 
 void installSkopeo() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -552,5 +552,5 @@ String[] getImages() {
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
-    return sh(script: "source ~/virtenvs/cekit/bin/activate && ${cmd}", returnStdout: stdout)
+    return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
 }

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -21,8 +21,8 @@ pipeline {
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
         // Linked to node label
-        CONTAINER_ENGINE='podman'
-        CONTAINER_ENGINE_TLS_OPTIONS='--tls-verify-false'
+        CONTAINER_ENGINE = 'podman'
+        CONTAINER_ENGINE_TLS_OPTIONS = '--tls-verify=false'
 
         OPENSHIFT_API = credentials('OPENSHIFT_API')
         OPENSHIFT_REGISTRY = credentials('OPENSHIFT_REGISTRY')
@@ -51,86 +51,34 @@ pipeline {
                         assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
 
-                    dir(getRepoName()) {
-                        checkoutRepo()
-                    }
-
-                    installGitHubReleaseCLI()
-                }
-            }
-        }
-        // stage('Update PR with released Maven artifacts') {
-        //     when {
-        //         expression { return isRelease() && getPRSourceBranch() != '' }
-        //     }
-        //     steps {
-        //         script {
-        //             // Update maven information with new artifacts from Maven central in the PR
-        //             dir('artifacts-update') {
-        //                 checkoutRepo()
-        //                 githubscm.forkRepo(getBotAuthorCredsID())
-        //
-        //                 // Get the working branch
-        //                 sh 'git fetch origin'
-        //                 sh "git checkout ${getPRSourceBranch()}"
-        //
-        //                 // Update artifacts
-        //                 updateArtifactCmd = 'python3 scripts/update-maven-artifacts.py'
-        //                 if (getMavenArtifactRepository() != '') {
-        //                     updateArtifactCmd += " --repo-url ${getMavenArtifactRepository()}"
-        //                 }
-        //                 sh updateArtifactCmd
-        //
-        //                 try {
-        //                     githubscm.commitChanges('Setup Maven artifacts to released ones')
-        //                     githubscm.pushObject('origin', getPRSourceBranch(), getBotAuthorCredsID())
-        //                 } catch (err) {
-        //                     String body = "Seems like no change is to be committed.\nPlease review in ${env.BUILD_URL}console.\n" +
-        //                             "And take your decision here: ${env.BUILD_URL}input"
-        //                     sendNotification(body, 'Release Pipeline')
-        //                    input message: 'Should the pipeline continue ?', ok: 'Yes'
-        //                }
-        //            }
-        //        }
-        //    }
-        // }
-        stage('Pull "old" images') {
-            steps {
-                script {
+                    // Login old registry
                     if (isOldImageInOpenshiftRegistry()) {
                         loginOpenshiftRegistry()
                     } else if (getOldImageRegistryCredentials() != '') {
                         loginContainerRegistry(getOldImageRegistry(), getOldImageRegistryCredentials())
                     }
-                    dir(getRepoName()) {
-                        pullImages()
-                    }
-                }
-            }
-        }
-        stage('Tag images') {
-            steps {
-                script {
-                    dir(getRepoName()) {
-                        tagImages()
-                    }
-                }
-            }
-        }
-        stage('Pushing "new" images') {
-            steps {
-                script {
+
+                    // Login new registry
                     if (isNewImageInOpenshiftRegistry()) {
                         loginOpenshiftRegistry()
                     } else if (getNewImageRegistryCredentials() != '') {
                         loginContainerRegistry(getNewImageRegistry(), getNewImageRegistryCredentials())
                     }
-                    dir(getRepoName()) {
-                        pushImages()
 
-                        if (isQuayRegistry(getNewImageRegistry())) {
-                            makeQuayNewImagesPublic()
-                        }
+                    dir(getRepoName()) {
+                        checkoutRepo()
+                    }
+
+                    installGitHubReleaseCLI()
+                    cloud.installSkopeo()
+                }
+            }
+        }
+        stage('Promote images') {
+            steps {
+                script {
+                    dir(getRepoName()) {
+                        promoteImages()
                     }
                 }
             }
@@ -212,10 +160,10 @@ void sendUnsuccessfulNotification() {
     }
 }
 
-void sendNotification(String body, String subjectProject = 'Kogito Images') {
+void sendNotification(String body) {
     emailext body: body,
         subject: getNotificationSubject()
-        to: env.KOGITO_CI_EMAIL_TO
+    to: env.KOGITO_CI_EMAIL_TO
 }
 
 String getNotificationSubject() {
@@ -235,60 +183,25 @@ void checkoutRepo() {
 
 void clean() {
     cleanWs()
-    cleanImages()
+    util.cleanNode()
+    cloud.cleanSkopeo()
 }
 
-void cleanImages() {
-    sh "${env.CONTAINER_ENGINE} rm -f \$(${env.CONTAINER_ENGINE} ps -a -q) || date"
-    sh "${env.CONTAINER_ENGINE} rmi -f \$(${env.CONTAINER_ENGINE} images -q) || date"
-}
-
-void pullImages() {
+void promoteImages() {
     for (String imageName : getImages()) {
-        pullImage(getOldImageFullTag(imageName))
-    }
-}
-
-void pullImage(String fullImageName) {
-    retry(env.MAX_REGISTRY_RETRIES) {
-        sh "${env.CONTAINER_ENGINE} pull ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${fullImageName}"
-    }
-}
-
-void tagImages() {
-    for (String imageName : getImages()) {
-        tagImage(getOldImageFullTag(imageName), getNewImageFullTag(imageName, getNewImageTag()))
+        promoteImage(getOldImageFullTag(imageName), getNewImageFullTag(imageName, getNewImageTag()))
         if (isDeployLatestTag()) {
-            tagImage(getOldImageFullTag(imageName), getNewImageFullTag(imageName, 'latest'))
+            promoteImage(getOldImageFullTag(imageName), getNewImageFullTag(imageName, 'latest'))
         }
         String reducedTag = getReducedTag()
         if (reducedTag) {
-            tagImage(getOldImageFullTag(imageName), getNewImageFullTag(imageName, reducedTag))
+            promoteImage(getOldImageFullTag(imageName), getNewImageFullTag(imageName, reducedTag))
         }
     }
 }
 
-void tagImage(String oldImageName, String newImageName) {
-    sh "${env.CONTAINER_ENGINE} tag ${oldImageName} ${newImageName}"
-}
-
-void pushImages() {
-    for (String imageName : getImages()) {
-        pushImage(getNewImageFullTag(imageName, getNewImageTag()))
-        if (isDeployLatestTag()) {
-            pushImage(getNewImageFullTag(imageName, 'latest'))
-        }
-        String reducedTag = getReducedTag()
-        if (reducedTag) {
-            pushImage(getNewImageFullTag(imageName, reducedTag))
-        }
-    }
-}
-
-void pushImage(String fullImageName) {
-    retry(env.MAX_REGISTRY_RETRIES) {
-        sh "${env.CONTAINER_ENGINE} push ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${fullImageName}"
-    }
+void promoteImage(String oldImageName, String newImageName) {
+    cloud.skopeoCopyRegistryImages(oldImageName, newImageName, Integer.parseInt(env.MAX_REGISTRY_RETRIES))
 }
 
 // Set images public on quay. Useful when new images are introduced.

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -182,5 +182,5 @@ String getCleanedReleaseNotes() {
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {
-    return sh(script: "source ~/virtenvs/cekit/bin/activate && ${cmd}", returnStdout: stdout)
+    return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
 }

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build-image: clone-repos _build-image
 _build-image:
 ifneq ($(ignore_build),true)
 	scripts/build-kogito-apps-components.sh ${image_name} ${KOGITO_APPS_TARGET_BRANCH} ${KOGITO_APPS_TARGET_URI};
-	${CEKIT_CMD} --descriptor ${image_name}-image.yaml build ${BUILD_ENGINE}
+	${CEKIT_CMD} --descriptor ${image_name}-image.yaml build ${build_options} ${BUILD_ENGINE}
 endif
 # tag with shortened version
 ifneq ($(ignore_tag),true)
@@ -69,7 +69,7 @@ build-prod-image: clone-repos _build-prod-image
 _build-prod-image:
 ifneq ($(ignore_build),true)
 	scripts/build-kogito-apps-components.sh ${image_name} ${KOGITO_APPS_TARGET_BRANCH} ${KOGITO_APPS_TARGET_URI};
-	scripts/build-product-image.sh "build" $(image_name) ${BUILD_ENGINE}
+	scripts/build-product-image.sh "build" $(image_name) ${build_options} ${BUILD_ENGINE}
 endif
 # if ignore_test is set to true, ignore the tests
 ifneq ($(ignore_test),true)
@@ -121,4 +121,4 @@ bats:
 prod_component=
 container-build-osbs:
 	echo "calling RHPAM container-build-osbs......................................"
-	$(CEKIT_CMD) --descriptor $(prod_component).yaml --redhat build osbs --assume-yes
+	$(CEKIT_CMD) --descriptor $(prod_component).yaml --redhat build ${build_options} osbs --assume-yes

--- a/container.yaml
+++ b/container.yaml
@@ -2,5 +2,6 @@
 platforms:
   only:
     - x86_64
+    - aarch64
 compose:
   pulp_repos: true

--- a/logic-data-index-ephemeral-rhel8-image.yaml
+++ b/logic-data-index-ephemeral-rhel8-image.yaml
@@ -54,6 +54,7 @@ osbs:
       platforms:
         only:
         - x86_64
+        - aarch64
         - ppc64le
       compose:
         pulp_repos: true

--- a/modules/kogito-graalvm-installer/22.3-java-11/configure
+++ b/modules/kogito-graalvm-installer/22.3-java-11/configure
@@ -3,14 +3,18 @@ set -e
 
 architecture=$(uname -i)
 
-if [ "$architecture" != x86_64 ]; then
-    exit 0;
+if [ "$architecture" = "x86_64" ]; then
+    arch='amd64'
+elif [ "$architecture" = "aarch64" ]; then
+    arch='aarch64'
+else
+    exit 0
 fi
 
 SOURCES_DIR=/tmp/artifacts
 SCRIPT_DIR=$(dirname "${0}")
 
-tar xzf "${SOURCES_DIR}"/graalvm-ce-java"${GRAALVM_JAVA_VERSION}"-linux-amd64-"${GRAALVM_VERSION}".tar.gz -C /usr/share
+tar xzf "${SOURCES_DIR}"/graalvm-ce-java"${GRAALVM_JAVA_VERSION}"-linux-${arch}-"${GRAALVM_VERSION}".tar.gz -C /usr/share
 mv /usr/share/graalvm-ce-java"${GRAALVM_JAVA_VERSION}"-"${GRAALVM_VERSION}" /usr/share/graalvm
 
 #KOGITO-384 - Add libsunec.so and cacerts to Kogito runtime native image

--- a/modules/kogito-graalvm-installer/22.3-java-11/module.yaml
+++ b/modules/kogito-graalvm-installer/22.3-java-11/module.yaml
@@ -17,9 +17,15 @@ artifacts:
   - name: graalvm-ce-java11-linux-amd64-22.3.2.tar.gz
     url: https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.2/graalvm-ce-java11-linux-amd64-22.3.2.tar.gz
     md5: 68c9e14932ac6c8606953b88aff89cf4
+  - name: graalvm-ce-java11-linux-aarch64-22.3.2.tar.gz
+    url: https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.2/graalvm-ce-java11-linux-aarch64-22.3.2.tar.gz
+    md5: 5cb31954ef5538057d83502c19492ad0
   - name: native-image-installable-svm-java11-linux-amd64-22.3.2.jar
     url: https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.2/native-image-installable-svm-java11-linux-amd64-22.3.2.jar
     md5: dae44733baf47ffaadf7ef98959b5653
+  - name: native-image-installable-svm-java11-linux-aarch64-22.3.2.jar
+    url: https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.2/native-image-installable-svm-java11-linux-aarch64-22.3.2.jar
+    md5: 9d87d8650aa17e2ec375a587dc445651
 
 execute:
   - script: configure

--- a/modules/kogito-graalvm-scripts/configure
+++ b/modules/kogito-graalvm-scripts/configure
@@ -2,9 +2,14 @@
 set -e
 
 architecture=$(uname -i)
+arch=${architecture}
 
-if [ "$architecture" != x86_64 ]; then
-    exit 0;
+if [ "$architecture" = "x86_64" ]; then
+    arch='amd64'
+elif [ "$architecture" = "aarch64" ]; then
+    arch='aarch64'
+else
+    exit 0
 fi
 
 SOURCES_DIR=/tmp/artifacts
@@ -12,4 +17,4 @@ SCRIPT_DIR=$(dirname "${0}")
 
 cp -v "${SCRIPT_DIR}"/added/* "${KOGITO_HOME}"/launch/
 
-/usr/share/graalvm/bin/gu -L install "${SOURCES_DIR}"/native-image-installable-svm-java"${GRAALVM_JAVA_VERSION}"-linux-amd64-"${GRAALVM_VERSION}".jar
+/usr/share/graalvm/bin/gu -L install "${SOURCES_DIR}"/native-image-installable-svm-java"${GRAALVM_JAVA_VERSION}"-linux-${arch}-"${GRAALVM_VERSION}".jar

--- a/modules/kogito-jobs-service-all-in-one/module.yaml
+++ b/modules/kogito-jobs-service-all-in-one/module.yaml
@@ -14,7 +14,7 @@ artifacts:
 
 packages:
   install:
-    - pam.x86_64
+    - pam
 
 execute:
   - script: configure

--- a/modules/kogito-jobs-service-ephemeral/module.yaml
+++ b/modules/kogito-jobs-service-ephemeral/module.yaml
@@ -10,7 +10,7 @@ artifacts:
 
 packages:
   install:
-    - pam.x86_64
+    - pam
 
 execute:
   - script: configure

--- a/scripts/build-kogito-apps-components.sh
+++ b/scripts/build-kogito-apps-components.sh
@@ -99,8 +99,10 @@ for ctx in ${contextDir}; do
 
     . ${script_dir_path}/setup-maven.sh "${build_target_dir}"/settings.xml
 
-    echo "Copy current maven repo to maven context local repo ${mvn_local_repo}"
-    cp -r ${HOME}/.m2/repository/* "${mvn_local_repo}"
+    if stat ${HOME}/.m2/repository/ &> /dev/null; then
+        echo "Copy current maven repo to maven context local repo ${mvn_local_repo}"
+        cp -r ${HOME}/.m2/repository/* "${mvn_local_repo}"
+    fi
 
     cd ${build_target_dir}
     echo "Using branch/tag ${gitBranch}, checking out. Temporary build dir is ${build_target_dir} and target dist is ${target_tmp_dir}"


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9181

depends on https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/278

Examples:
- [deploy](https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/blue/organizations/jenkins/custom%2Ftradisso%2Fkogito-images-test-nightly-multiplatform/detail/kogito-images-test-nightly-multiplatform/77/pipeline/)
- [promote](https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/blue/organizations/jenkins/custom%2Ftradisso%2Fkogito-images-test-nightly-promote-multiplatform/detail/kogito-images-test-nightly-promote-multiplatform/2/pipeline/)
- [final created images](https://quay.io/repository/tradisso/kogito-swf-builder-nightly?tab=tags)