### PR TITLE
KOGITO-9351 CI: Deploy: Externalize build image job

### DIFF
--- a/.ci/jenkins/Jenkinsfile
+++ b/.ci/jenkins/Jenkinsfile
@@ -1,14 +1,8 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
-changeAuthor = env.ghprbAuthorRepoGitUrl ? util.getGroup(env.ghprbAuthorRepoGitUrl) : (env.ghprbPullAuthorLogin ?: CHANGE_AUTHOR)
-changeBranch = env.ghprbSourceBranch ?: CHANGE_BRANCH
-changeTarget = env.ghprbTargetBranch ?: CHANGE_TARGET
-
-BUILD_FAILED_IMAGES = []
-
 pipeline {
     agent {
-        label 'kie-rhel8 && docker && kie-mem24g && !built-in'
+        label 'rhel8 && !built-in'
     }
     tools {
         maven env.BUILD_MAVEN_TOOL
@@ -17,31 +11,13 @@ pipeline {
     options {
         timeout(time: 120, unit: 'MINUTES')
     }
-    environment {
-        CI = true
-
-        // Linked to node label
-        // Use docker due to multiplatform build
-        CONTAINER_ENGINE='docker'
-        CONTAINER_ENGINE_TLS_OPTIONS=''
-
-        IMAGE_BUILD_PLATFORMS = 'linux/amd64,linux/arm64'
-    }
     stages {
         stage('Initialization') {
             steps {
                 script {
                     clean()
 
-                    githubscm.checkoutIfExists('kogito-images', changeAuthor, changeBranch, 'kiegroup', changeTarget, true)
-
-                    if (isProdCI()) {
-                        // Prod fix to be able to build the image as a community one
-                        sh "echo '' > content_sets.yaml"
-                    }
-
-                    cloud.prepareForDockerMultiplatformBuild()
-                    cloud.startLocalRegistry()
+                    githubscm.checkoutIfExists('kogito-images', getChangeAuthor(), getChangeBranch(), 'kiegroup', getChangeTarget(), true)
                 }
             }
         }
@@ -58,76 +34,14 @@ pipeline {
                 }
             }
         }
-        stage('Prepare environment') {
-            steps {
-                script {
-                    // Set the mirror url only if exist
-                    if (env.MAVEN_MIRROR_REPOSITORY) {
-                        env.MAVEN_MIRROR_URL = env.MAVEN_MIRROR_REPOSITORY
-                        
-                        // Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
-                        runPythonCommand("python3 scripts/update-repository.py --build-maven-mirror-url ${MAVEN_MIRROR_URL} --ignore-self-signed-cert")
-                    }
-                }
-            }
-        }
-        // Commented as we cannot fully rely on Quarkus platform
-        // Should be uncommmented once https://issues.redhat.com/browse/KOGITO-9120 is implemented
-        // stage('Setup Quarkus platform') {
-        //     steps {
-        //         script {
-        //             String kogitoVersion = sh(returnStdout: true, script: 'make display-kogito-version')
-        //             String quarkusPlatformVersion = "kogito-${kogitoVersion}"
-
-        //             // Setup quarkus platform repo configuration
-        //             runPythonCommand("python3 scripts/update-repository.py --repo-url ${QUARKUS_PLATFORM_NEXUS_URL} --ignore-self-signed-cert --quarkus-platform-version ${quarkusPlatformVersion}")
-        //         }
-        //     }
-        // }
-        stage('Prepare offline kogito-examples') {
-            steps {
-                script {
-                    runPythonCommand('make clone-repos')
-                }
-            }
-        }
         stage('Build & Test Images') {
             steps {
                 script {
                     parallelStages = [:]
-                    getImages().each { image ->
-                        initWorkspace(image)
-                        String workspacePath = getWorkspacePath(image)
-                        parallelStages["Build&Test ${image}"] = {
-                            stage("Build/Test ${image}") {
-                                dir(workspacePath) {
-                                    try {
-                                        buildImage(image)
-                                    } catch (err) {
-                                        registerBuildFailedImage(image)
-                                        util.archiveConsoleLog(image, 400)
-                                        throw err
-                                    }
-                                    try {
-                                        testImage(image)
-                                    } catch (err) {
-                                        echo "Testing error(s) for image ${image}"
-                                    } finally {
-                                        junit testResults: 'target/**/*.xml', allowEmptyResults: true
-                                        archiveArtifacts artifacts: 'target/**/*.xml', allowEmptyArchive: true
-                                    }
-                                }
-                            }
-                        }
+                    for(String image : getImages()){
+                        parallelStages[image] = createBuildAndTestStageClosure(image)
                     }
                     parallel parallelStages
-                }
-            }
-            post {
-                always {
-                    script {
-                        cleanWorkspaces()
-                    }
                 }
             }
         }
@@ -140,98 +54,37 @@ pipeline {
         }
         unsuccessful {
             script {
-                def additionalInfo = ''
-                if (getBuildFailedImages()) {
-                    additionalInfo += 'Build failures on those images:\n'
-                    getBuildFailedImages().each {
-                        additionalInfo += "- ${it}\n"
-                    }
-                }
-                pullrequest.postComment(util.getMarkdownTestSummary('PR', additionalInfo, "${BUILD_URL}", 'GITHUB'))
+                pullrequest.postComment(util.getMarkdownTestSummary(isProdCI() ? 'Prod' : 'PR', '', "${BUILD_URL}", 'GITHUB'))
             }
         }
     }
 }
 
 void clean() {
-    cleanWorkspaces()
-    util.cleanNode(env.CONTAINER_ENGINE)
-    
-    cloud.cleanDockerMultiplatformBuild()
-    cloud.cleanLocalRegistry()
-
-    // Clean Cekit cache, in case we reuse an old node
-    sh "rm -rf \$HOME/.cekit/cache"
+    util.cleanNode()
 }
 
-void launchParallelForEachImage(stageNamePrefix, executeOnImage) {
-    parallelStages = [:]
-    getImages().each { image ->
-        parallelStages["${stageNamePrefix} ${image}"] = {
-            dir(getWorkspacePath(image)) {
-                executeOnImage(image)
+Closure createBuildAndTestStageClosure(String image) {
+    return {
+        stage("Build&Test ${image}") {
+            List buildParams = []
+            buildParams.add(string(name: "DISPLAY_NAME", value: "PR #${ghprbPullId} - ${image}: ${ghprbPullLink}"))
+            buildParams.add(string(name: 'BUILD_IMAGE_NAME', value: image))
+            buildParams.add(string(name: 'SOURCE_AUTHOR', value: getChangeAuthor()))
+            buildParams.add(string(name: 'SOURCE_BRANCH', value: getChangeBranch()))
+            buildParams.add(string(name: 'TARGET_BRANCH', value: getChangeTarget()))
+            buildParams.add(string(name: 'BUILD_KOGITO_APPS_REF', value: getChangeTarget()))
+
+            def job = build(job: "kogito-images.build-image", wait: true, parameters: buildParams, propagate: false)
+            if (job.result != 'SUCCESS') {
+                if (job.result == 'UNSTABLE') {
+                    unstable("Tests on ${image} seems to have failed")
+                } else {
+                    error("Error building ${image}. Please check the logs of the job: ${job.absoluteUrl}")
+                }
             }
         }
     }
-    parallel parallelStages
-}
-
-void buildImage(String imageName) {
-    // Generate the Dockerfile
-    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
-
-    // Build multiplatform from generated Dockerfile
-    dir('target/image') {
-        cloud.dockerBuildMultiPlatformImages(getTempBuiltImageTag(imageName), getImageBuildPlatforms(), false)
-    }
-}
-
-void testImage(String imageName) {
-    String testImageTag = "quay.io/kiegroup/${imageName}:${getImageVersion()}"
-    String tempBuiltImageTag = getTempBuiltImageTag(imageName)
-    // Pull and tag to test image
-    sh """
-        docker pull ${tempBuiltImageTag}
-        docker tag ${tempBuiltImageTag} ${testImageTag}
-    """
-    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_build=true ignore_test_prepare=true ignore_tag=${isProdCI()}")
-}
-
-String getMakeBuildImageArgs() {
-    List args = [ "cekit_option='--work-dir .'" ]
-    args.add("KOGITO_APPS_TARGET_BRANCH=${changeTarget}")
-    args.add("BUILD_ENGINE=${CONTAINER_ENGINE}")
-    if (env.CONTAINER_ENGINE_TLS_OPTIONS) {
-        args.add("BUILD_ENGINE_TLS_OPTIONS=${CONTAINER_ENGINE_TLS_OPTIONS}")   
-    }
-    return args.join(' ')
-}
-
-void registerBuildFailedImage(String imageName) {
-    lock("${BUILD_URL} build failed") {
-        BUILD_FAILED_IMAGES.add(imageName)
-    }
-}
-
-List getBuildFailedImages() {
-    return BUILD_FAILED_IMAGES
-}
-
-void initWorkspace(String image) {
-    sh "mkdir -p ${getWorkspacePath(image)}"
-    sh "rsync -av --progress . ${getWorkspacePath(image)} --exclude workspaces"
-}
-
-void cleanWorkspaces() {
-    sh "rm -rf ${getWorkspacesPath()}"
-}
-
-String getWorkspacesPath() {
-    return "${WORKSPACE}/workspaces"
-}
-
-String getWorkspacePath(String image) {
-    return "${getWorkspacesPath()}/${image}"
 }
 
 String[] getImages() {
@@ -239,26 +92,21 @@ String[] getImages() {
     if (isProdCI()) {
         listCmd += ' arg=--prod'
     }
-    return runPythonCommand("${listCmd} | tr '\\n' ','", true).trim().split(',')
-}
-
-List getImageBuildPlatforms() {
-    return "${IMAGE_BUILD_PLATFORMS}".split(',') as List
-}
-
-String getImageVersion() {
-    return runPythonCommand('make display-image-version', true).trim()
+    return util.runWithPythonVirtualEnv("${listCmd} | tr '\\n' ','", 'cekit', true).trim().split(',')
 }
 
 boolean isProdCI() {
     return env.PROD_CI ? env.PROD_CI.toBoolean() : false
 }
 
-String getTempBuiltImageTag(String imageName) {
-    return "localhost:5000/${imageName}:${githubscm.getCommitHash()}"
+String getChangeAuthor() {
+    return env.ghprbAuthorRepoGitUrl ? util.getGroup(env.ghprbAuthorRepoGitUrl) : (env.ghprbPullAuthorLogin ?: CHANGE_AUTHOR)
 }
 
-void runPythonCommand(String cmd, boolean stdout = false) {
-    return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
+String getChangeBranch() {
+    return env.ghprbSourceBranch ?: CHANGE_BRANCH
 }
 
+String getChangeTarget() {
+    return env.ghprbTargetBranch ?: CHANGE_TARGET
+}

--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -1,0 +1,349 @@
+ @Library('jenkins-pipeline-shared-libraries')_
+
+QUAY_REGISTRY = 'quay.io'
+
+pipeline {
+    agent {
+        label 'kie-rhel8 && docker && !built-in'
+    }
+    tools {
+        maven env.BUILD_MAVEN_TOOL
+        jdk env.BUILD_JDK_TOOL
+    }
+    options {
+        timeout(time: 120, unit: 'MINUTES')
+    }
+    environment {
+        CI = true
+
+        // Linked to node label
+        // Use docker due to multiplatform build
+        CONTAINER_ENGINE = 'docker'
+        CONTAINER_ENGINE_TLS_OPTIONS = ''
+
+        OPENSHIFT_API = credentials('OPENSHIFT_API')
+        OPENSHIFT_REGISTRY = credentials('OPENSHIFT_REGISTRY')
+        OPENSHIFT_CREDS_KEY = 'OPENSHIFT_CREDS'
+
+        IMAGE_BUILD_PLATFORMS = 'linux/amd64,linux/arm64'
+    }
+    stages {
+        stage('Initialization') {
+            steps {
+                script {
+                    clean()
+
+                    assert getBuildImageName() : 'Please provide `BUILD_IMAGE_NAME` parameter'
+
+                    currentBuild.displayName = params.DISPLAY_NAME ?: currentBuild.displayName
+
+                    if (getTargetBranch()) {
+                        echo "Got a target branch ... Trying to merge the source with the target"
+                        githubscm.checkoutIfExists(getRepoName(), getSourceAuthor(), getSourceBranch(), getTargetAuthor(), getTargetBranch(), true)
+                    } else {
+                        echo "No target branch ... Checking out simply"
+                        checkout(githubscm.resolveRepository(getRepoName(), getSourceAuthor(), getSourceBranch(), false))
+                    }
+
+                    if (isProdCI()) {
+                        // Prod fix to be able to build the image as a community one
+                        sh "echo '' > content_sets.yaml"
+                    }
+
+                    // Login to final registry if deploy is needed
+                    if (shouldDeployImage()) {
+                        if (isDeployImageInOpenshiftRegistry()) {
+                            cloud.loginOpenShift(env.OPENSHIFT_API, env.OPENSHIFT_CREDS_KEY)
+                            cloud.loginOpenshiftRegistry(env.CONTAINER_ENGINE, env.CONTAINER_ENGINE_TLS_OPTIONS ?: '')
+                        } else if (getDeployImageRegistryCredentials()) {
+                            cloud.loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials(), env.CONTAINER_ENGINE, env.CONTAINER_ENGINE_TLS_OPTIONS ?: '')
+                        }
+                    }
+                }
+            }
+        }
+        stage('Prepare environment') {
+            steps {
+                script {
+                    cloud.prepareForDockerMultiplatformBuild()
+                    cloud.startLocalRegistry()
+                    if (shouldDeployImage()) {
+                        cloud.installSkopeo()
+                    }
+
+                    // Set the mirror url only if exist
+                    if (env.MAVEN_MIRROR_REPOSITORY) {
+                        env.MAVEN_MIRROR_URL = env.MAVEN_MIRROR_REPOSITORY
+
+                        // Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
+                        runPythonCommand("python3 scripts/update-repository.py --build-maven-mirror-url ${MAVEN_MIRROR_URL} --ignore-self-signed-cert")
+                    }
+                }
+            }
+        }
+        // Commented as we cannot fully rely on Quarkus platform
+        // Should be uncommmented once https://issues.redhat.com/browse/KOGITO-9120 is implemented
+        // stage('Setup Quarkus platform') {
+        //     steps {
+        //         script {
+        //             if (getQuarkusPlatformURL()) {
+        //                 String kogitoVersion = sh(returnStdout: true, script: 'make display-kogito-version')
+        //                 String quarkusPlatformVersion = "kogito-${kogitoVersion}"
+        //                 if (getMavenArtifactRepository()) {
+        //                     echo "[WARN] Artifacts repository defined in env will override the quarkus platform URL in tests. Make sure the platform artifacts are available on that artifacts repository (you can use a maven group)"
+        //                 }
+        //                 // Setup quarkus platform repo configuration
+        //                 runPythonCommand("python3 scripts/update-repository.py --repo-url ${getQuarkusPlatformURL()} --ignore-self-signed-cert --quarkus-platform-version ${quarkusPlatformVersion}")
+        //             }
+        //         }
+        //     }
+        // }
+        stage('Build image') {
+            steps {
+                script {
+                    // Generate the Dockerfile
+                    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${getBuildImageName()} ignore_test=true ignore_tag=true build_options='--dry-run'")
+
+                    // Build multiplatform from generated Dockerfile
+                    String squashMessage = "${getBuildImageName()}:${getImageVersion()} squashed"
+                    dir('target/image') {
+                        cloud.dockerBuildMultiPlatformImages(getBuiltImageTag(), getImageBuildPlatforms(), shouldDeployImage(), squashMessage)
+                    }
+                }
+            }
+        }
+        stage('Push tags') {
+            when {
+                expression { return shouldDeployImage() }
+            }
+            steps {
+                script {
+                    // Make public if quay registry
+                    if (getDeployImageRegistry() == QUAY_REGISTRY) {
+                        String namespace = getDeployImageNamespace()
+                        String repository = getFinalImageName()
+                        echo "Check and set public if needed Quay repository ${namespace}/${repository}"
+                        try {
+                            cloud.makeQuayImagePublic(namespace, repository, [ usernamePassword: getDeployImageRegistryCredentials()])
+                        } catch (err) {
+                            echo "[ERROR] Cannot set image quay.io/${namespace}/${repository} as visible"
+                        }
+                    }
+
+                    int retries = Integer.parseInt(env.MAX_REGISTRY_RETRIES)
+                    String imageTag = getBuiltImageTag()
+                    if (isDeployLatestTag()) {
+                        cloud.skopeoCopyRegistryImages(imageTag, getBuiltImageTag('latest'), retries)
+                    }
+                    try {
+                        cloud.skopeoCopyRegistryImages(cloud.getReducedTag(getDeployImageTag()), getBuiltImageTag(reducedTag), retries)
+                    } catch(err) {
+                        echo "Reduced tag cannot be applied"
+                    }
+                }
+            }
+        }
+        stage('Setup for testing') {
+            when {
+                expression { return !shouldSkipTests() }
+            }
+            steps {
+                script {
+                    updateTestsCommand = 'python3 scripts/update-repository.py --tests-only'
+                    updateTestsCommand += getMavenArtifactRepository() ? " --repo-url ${getMavenArtifactRepository()}" : ''
+                    updateTestsCommand += getTestsKogitoExamplesRef() ? " --examples-ref ${getTestsKogitoExamplesRef()}" : ''
+                    updateTestsCommand += getTestsKogitoExamplesURI() ? " --examples-uri ${getTestsKogitoExamplesURI()}" : ''
+
+                    // Launch update tests
+                    runPythonCommand(updateTestsCommand)
+
+                    // Debug purpose in case of issue
+                    sh 'cat tests/test-apps/clone-repo.sh'
+                    sh 'cat scripts/setup-maven.sh'
+                    sh 'cat tests/features/kogito-s2i-builder.feature'
+                }
+            }
+        }
+        stage('Test image') {
+            when {
+                expression { return !shouldSkipTests() }
+            }
+            steps {
+                script {
+                    String testImageTag = "quay.io/kiegroup/${getBuildImageName()}:${getImageVersion()}"
+                    String builtImageTag = getBuiltImageTag()
+                    // Pull and tag to test image
+                    sh """
+                        docker pull ${builtImageTag}
+                        docker tag ${builtImageTag} ${testImageTag}
+                    """
+                    try {
+                        runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${getBuildImageName()} ignore_build=true ignore_tag=${isProdCI()}")
+                    } catch (err) {
+                        unstable "Testing error(s) for image ${getBuildImageName()}"
+                    } finally {
+                        junit testResults: 'target/**/*.xml', allowEmptyResults: true
+                        archiveArtifacts artifacts: 'target/**/*.xml', allowEmptyArchive: true
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                clean()
+            }
+        }
+    }
+}
+
+void clean() {
+    util.cleanNode(env.CONTAINER_ENGINE)
+
+    cloud.cleanDockerMultiplatformBuild()
+    cloud.cleanLocalRegistry()
+    cloud.cleanSkopeo()
+
+    // Clean Cekit cache, in case we reuse an old node
+    sh "rm -rf \$HOME/.cekit/cache"
+}
+
+String getMakeBuildImageArgs() {
+    List args = []
+    if (getBuildKogitoAppsRef()) {
+        args.add("KOGITO_APPS_TARGET_BRANCH=${getBuildKogitoAppsRef()}")
+    }
+    if (getBuildKogitoAppsURI()) {
+        args.add("KOGITO_APPS_TARGET_URI=${getBuildKogitoAppsURI()}")
+    }
+    args.add("BUILD_ENGINE=${CONTAINER_ENGINE}")
+    if (env.CONTAINER_ENGINE_TLS_OPTIONS) {
+        args.add("BUILD_ENGINE_TLS_OPTIONS=${CONTAINER_ENGINE_TLS_OPTIONS}")
+    }
+    return args.join(' ')
+}
+
+String getImageVersion() {
+    return runPythonCommand('make display-image-version', true).trim()
+}
+
+String getBuiltImageTag(String imageTag = '') {
+    if (shouldDeployImage()) {
+        return "${getDeployImageRegistry()}/${getDeployImageNamespace()}/${getFinalImageName()}:${imageTag ?: getDeployImageTag()}"
+    } else {
+        return "localhost:5000/${getBuildImageName()}:${githubscm.getCommitHash()}"
+    }
+}
+
+void runPythonCommand(String cmd, boolean stdout = false) {
+    return util.runWithPythonVirtualEnv(cmd, 'cekit', stdout)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Deploy image information
+////////////////////////////////////////////////////////////////////////
+
+boolean isDeployImageInOpenshiftRegistry() {
+    return params.DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY
+}
+
+String getDeployImageRegistryCredentials() {
+    return params.DEPLOY_IMAGE_REGISTRY_CREDENTIALS
+}
+
+String getDeployImageRegistry() {
+    return isDeployImageInOpenshiftRegistry() ? env.OPENSHIFT_REGISTRY : params.DEPLOY_IMAGE_REGISTRY
+}
+
+String getDeployImageNamespace() {
+    return isDeployImageInOpenshiftRegistry() ? 'openshift' : params.DEPLOY_IMAGE_NAMESPACE
+}
+
+String getDeployImageNameSuffix() {
+    return params.DEPLOY_IMAGE_NAME_SUFFIX
+}
+
+String getDeployImageTag() {
+    if (params.DEPLOY_IMAGE_TAG != '') {
+        return params.DEPLOY_IMAGE_TAG
+    } else {
+        return sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+    }
+}
+
+String getFinalImageName() {
+    return getBuildImageName() + (getDeployImageNameSuffix() ? "-${getDeployImageNameSuffix()}" : '')
+}
+
+boolean isDeployLatestTag() {
+    return params.DEPLOY_WITH_LATEST_TAG
+}
+
+////////////////////////////////////////////////////////////////////////
+// utils
+////////////////////////////////////////////////////////////////////////
+
+String getRepoName() {
+    return env.REPO_NAME
+}
+
+String getBuildImageName() {
+    return params.BUILD_IMAGE_NAME
+}
+
+String getSourceAuthor() {
+    return params.SOURCE_AUTHOR
+}
+
+String getSourceBranch() {
+    return params.SOURCE_BRANCH
+}
+
+String getTargetAuthor() {
+    return env.TARGET_AUTHOR
+}
+
+String getTargetBranch() {
+    return params.TARGET_BRANCH
+}
+
+boolean shouldDeployImage() {
+    return params.DEPLOY_IMAGE
+}
+
+String getBuildKogitoAppsRef() {
+    return params.BUILD_KOGITO_APPS_REF
+}
+
+String getBuildKogitoAppsURI() {
+    return params.BUILD_KOGITO_APPS_URI
+}
+
+String getTestsKogitoExamplesRef() {
+    return params.TESTS_KOGITO_EXAMPLES_REF
+}
+
+String getTestsKogitoExamplesURI() {
+    return params.TESTS_KOGITO_EXAMPLES_URI
+}
+
+boolean shouldSkipTests() {
+    return params.SKIP_TESTS
+}
+
+List getImageBuildPlatforms() {
+    return "${IMAGE_BUILD_PLATFORMS}".split(',') as List
+}
+
+String getMavenArtifactRepository() {
+    return params.TESTS_MAVEN_ARTIFACTS_REPOSITORY_URL
+}
+
+boolean isProdCI() {
+    return env.PROD_CI ? Boolean.parseBoolean(env.PROD_CI) : false
+}
+
+String getQuarkusPlatformURL() {
+    return params.QUARKUS_PLATFORM_URL
+}

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -1,8 +1,8 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
-deployProperties = [ : ]
+deployProperties = [:]
 
-commitDone = false
+changesDone = false
 
 BUILT_IMAGES = []
 BUILD_FAILED_IMAGES = []
@@ -10,7 +10,7 @@ TEST_FAILED_IMAGES = []
 
 pipeline {
     agent {
-        label 'kie-rhel8 && docker && kie-mem24g && !built-in'
+        label 'rhel8 && !built-in'
     }
 
     // Needed for local build
@@ -23,29 +23,10 @@ pipeline {
         timeout(time: 120, unit: 'MINUTES')
     }
 
-    // parameters {
-    // For parameters, check into ./dsl/jobs.groovy file
-    // }
-
     environment {
-        // Static env is defined into ./dsl/jobs.groovy file
-
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
-        JAVA_HOME = "${GRAALVM_HOME}"
-
-        // Linked to node label
-        // Use docker due to multiplatform build
-        CONTAINER_ENGINE = 'docker'
-        CONTAINER_ENGINE_TLS_OPTIONS = ''
-
-        OPENSHIFT_API = credentials('OPENSHIFT_API')
-        OPENSHIFT_REGISTRY = credentials('OPENSHIFT_REGISTRY')
-        OPENSHIFT_CREDS_KEY = 'OPENSHIFT_CREDS'
-
         BOT_BRANCH_HASH = "${util.generateHash(10)}"
-
-        IMAGE_BUILD_PLATFORMS = 'linux/amd64,linux/arm64'
     }
 
     stages {
@@ -54,9 +35,7 @@ pipeline {
                 script {
                     clean()
 
-                    if (params.DISPLAY_NAME) {
-                        currentBuild.displayName = params.DISPLAY_NAME
-                    }
+                    currentBuild.displayName = params.DISPLAY_NAME ?: currentBuild.displayName
 
                     checkoutRepo()
 
@@ -65,17 +44,6 @@ pipeline {
                         assert getProjectVersion()
                         assert getBuildBranch() == util.getReleaseBranchFromVersion(getProjectVersion())
                     }
-
-                    // Login to final registry
-                    if (isDeployImageInOpenshiftRegistry()) {
-                        loginOpenshiftRegistry()
-                    } else if (getDeployImageRegistryCredentials()) {
-                        loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials())
-                    }
-
-                    cloud.prepareForDockerMultiplatformBuild()
-                    cloud.startLocalRegistry()
-                    cloud.installSkopeo()
                 }
             }
             post {
@@ -90,9 +58,10 @@ pipeline {
                 }
             }
         }
+
         stage('Prepare for PR') {
             when {
-                expression { return isRelease() || isCreateChangesPR() }
+                expression { return isRelease() }
             }
             steps {
                 script {
@@ -101,9 +70,27 @@ pipeline {
                 }
             }
         }
+
+        stage('Setup Quarkus platform version') {
+            when {
+                expression { isRelease() }
+            }
+            steps {
+                script {
+                    if (getQuarkusPlatformVersion()) {
+                        runPythonCommand("python3 scripts/update-repository.py --quarkus-platform-version ${getQuarkusPlatformVersion()}")
+
+                        commitAndPushChanges("Update Quarkus Platform version to ${getQuarkusPlatformVersion()}")
+                    } else {
+                        echo 'No new quarkus version given for the release. Statu quo ...'
+                    }
+                }
+            }
+        }
+
         stage('Update project version') {
             when {
-                expression { return getProjectVersion() != '' }
+                expression { return isRelease() }
             }
             steps {
                 script {
@@ -116,10 +103,11 @@ pipeline {
                     }
                     runPythonCommand(versionCmd)
 
-                    commitChanges("Update project version to ${getProjectVersion()}")
+                    commitAndPushChanges("Update project version to ${getProjectVersion()}")
                 }
             }
         }
+
         stage('Validate CeKit Image and Modules descriptors') {
             steps {
                 script {
@@ -138,127 +126,15 @@ pipeline {
                 }
             }
         }
-        stage('Prepare environment') {
-            steps {
-                script {
-                    // Set the mirror url only if exist
-                    if (env.MAVEN_MIRROR_REPOSITORY) {
-                        env.MAVEN_MIRROR_URL = env.MAVEN_MIRROR_REPOSITORY
 
-                        // Ignore self-signed certificates if MAVEN_MIRROR_URL is defined
-                        runPythonCommand("python3 scripts/update-repository.py --build-maven-mirror-url ${MAVEN_MIRROR_URL} --ignore-self-signed-cert")
-                    }
-                }
-            }
-        }
-        // Commented as we cannot fully rely on Quarkus platform
-        // Should be uncommmented once https://issues.redhat.com/browse/KOGITO-9120 is implemented
-        // stage('Setup Quarkus platform') {
-        //     steps {
-        //         script {
-        //             String kogitoVersion = sh(returnStdout: true, script: 'make display-kogito-version')
-        //             String quarkusPlatformVersion = "kogito-${kogitoVersion}"
-
-        //             if (isRelease()) {
-        //                 if (params.QUARKUS_PLATFORM_VERSION) {
-        //                     runPythonCommand("python3 scripts/update-repository.py --quarkus-platform-version ${params.QUARKUS_PLATFORM_VERSION}")
-        //                 } else {
-        //                     echo "No new quarkus version given for the release. Statu quo ..."
-        //                 }
-        //             } else {
-        //                 if (getMavenArtifactRepository()) {
-        //                     echo "[WARN] Artifacts repository defined in env will override the quarkus platform URL in tests. Make sure the platform artifacts are available on that artifacts repository (you can use a maven group)"
-        //                 }
-        //                 // Setup quarkus platform repo configuration
-        //                 runPythonCommand("python3 scripts/update-repository.py --repo-url ${QUARKUS_PLATFORM_NEXUS_URL} --ignore-self-signed-cert --quarkus-platform-version ${quarkusPlatformVersion}")
-        //             }
-        //         }
-        //     }
-        // }
-        stage('Setup for testing') {
-            when {
-                expression { return !shouldSkipTests() }
-            }
-            steps {
-                script {
-                    updateTestsCommand = 'python3 scripts/update-repository.py --tests-only'
-                    if (getMavenArtifactRepository()) {
-                        // Update repo in tests
-                        updateTestsCommand += " --repo-url ${getMavenArtifactRepository()}"
-                    }
-
-                    // Set kogito-examples to bot author/branch if release
-                    if (params.EXAMPLES_REF) {
-                        updateTestsCommand += " --examples-ref ${params.EXAMPLES_REF}"
-                    }
-                    if (params.EXAMPLES_URI) {
-                        updateTestsCommand += " --examples-uri ${params.EXAMPLES_URI}"
-                    }
-
-                    // Launch update tests
-                    runPythonCommand(updateTestsCommand)
-
-                    // Debug purpose in case of issue
-                    sh 'cat tests/test-apps/clone-repo.sh'
-                    sh 'cat scripts/setup-maven.sh'
-                    sh 'cat tests/features/kogito-s2i-builder.feature'
-
-                    // Prepare local examples
-                    runPythonCommand('make clone-repos')
-                }
-            }
-        }
-        stage('Build & Test Images') {
+        stage('Build, Push & Test Images') {
             steps {
                 script {
                     parallelStages = [:]
                     getImages().each { image ->
-                        initWorkspace(image)
-                        String workspacePath = getWorkspacePath(image)
-                        parallelStages["Build&Test ${image}"] = {
-                            stage("Build/Test ${image}") {
-                                dir(workspacePath) {
-                                    try {
-                                        buildImage(image)
-                                        registerBuiltImage(image)
-                                    } catch (err) {
-                                        registerBuildFailedImage(image)
-                                        util.archiveConsoleLog(image, 400)
-                                        unstable("Error building the '${image}' image")
-                                    }
-                                    if (!shouldSkipTests()) {
-                                        try {
-                                            testImage(image)
-                                        } catch (err) {
-                                            registerTestFailedImage(image)
-                                        } finally {
-                                            junit testResults: 'target/test/results/*.xml', allowEmptyResults: true
-                                            archiveArtifacts artifacts: 'target/test/results/*.xml', allowEmptyArchive: true
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        parallelStages["Build&Test ${image}"] = createBuildAndTestStageClosure(image)
                     }
                     parallel parallelStages
-                }
-            }
-            post {
-                always {
-                    script {
-                        cleanWorkspaces()
-                    }
-                }
-            }
-        }
-        stage('Push to registry') {
-            steps {
-                script {
-                    pushFinalImages()
-
-                    if (isQuayRegistry()) {
-                        makeQuayImagesPublic()
-                    }
                 }
             }
             post {
@@ -275,16 +151,15 @@ pipeline {
                 }
             }
         }
+
         stage('Create PR') {
             when {
                 expression {
-                    return commitDone && (isRelease() || isCreateChangesPR())
+                    return changesDone && isRelease()
                 }
             }
             steps {
                 script {
-                    githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
-
                     def commitMsg = "[${getBuildBranch()}] Update Maven artifacts"
                     def prBody = "Generated by build ${BUILD_TAG}: ${BUILD_URL}."
                     if (isRelease()) {
@@ -316,10 +191,6 @@ pipeline {
                     }
                     String prLink = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getBotAuthorCredsID())
                     deployProperties["${getRepoName()}.pr.link"] = prLink
-
-                    if (isCreateChangesPR()) {
-                        sendNotification("PR has been created with update Maven artifacts.\nPlease review it here: ${prLink}")
-                    }
                 }
             }
             post {
@@ -347,7 +218,7 @@ pipeline {
         always {
             script {
                 def propertiesStr = deployProperties.collect { entry -> "${entry.key}=${entry.value}" }.join('\n')
-                writeFile( file : env.PROPERTIES_FILE_NAME , text : propertiesStr)
+                writeFile(file : env.PROPERTIES_FILE_NAME , text : propertiesStr)
                 archiveArtifacts artifacts: env.PROPERTIES_FILE_NAME, allowEmptyArchive:true
             }
         }
@@ -383,57 +254,56 @@ void checkoutRepo() {
     checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false))
 }
 
-void commitChanges(String commitMsg) {
+void commitAndPushChanges(String commitMsg) {
     githubscm.commitChanges(commitMsg)
-    commitDone = true
+    githubscm.pushObject('origin', getBotBranch(), getBotAuthorCredsID())
+    changesDone = true
 }
 
 void clean() {
-    cleanWs()
-    util.cleanNode(env.CONTAINER_ENGINE)
-
-    cloud.cleanDockerMultiplatformBuild()
-    cloud.cleanLocalRegistry()
-    cloud.cleanSkopeo()
-
-    // Clean Cekit cache, in case we reuse an old node
-    sh 'rm -rf \$HOME/.cekit/cache'
+    util.cleanNode()
 }
 
-void buildImage(String imageName) {
-    // Generate the Dockerfile
-    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_test=true ignore_tag=true build_options='--dry-run'")
+void createBuildAndTestStageClosure(String image) {
+    return  {
+        stage("Build&Test ${image}") {
+            List buildParams = []
+            buildParams.add(string(name: 'DISPLAY_NAME', value: "${params.DISPLAY_NAME} - ${image}"))
+            buildParams.add(string(name: 'BUILD_IMAGE_NAME', value: image))
+            buildParams.add(string(name: 'SOURCE_AUTHOR', value: isRelease() ? getBotAuthor() : getGitAuthor()))
+            buildParams.add(string(name: 'SOURCE_BRANCH', value: isRelease() ? getBotBranch() : getBuildBranch()))
 
-    // Build multiplatform from generated Dockerfile
-    String tempBuiltImageTag = getTempBuiltImageTag(imageName)
-    String squashMessage = "${imageName}:${getImageVersion()} squashed"
-    dir('target/image') {
-        cloud.dockerBuildMultiPlatformImages(tempBuiltImageTag, getImageBuildPlatforms(), true, squashMessage)
-    }
-}
+            buildParams.add(string(name: 'BUILD_KOGITO_APPS_URI', value: params.APPS_URI))
+            buildParams.add(string(name: 'BUILD_KOGITO_APPS_REF', value: params.APPS_REF))
+            buildParams.add(booleanParam(name: 'SKIP_TESTS', value: params.SKIP_TESTS))
+            buildParams.add(string(name: 'TESTS_KOGITO_EXAMPLES_URI', value: params.EXAMPLES_URI))
+            buildParams.add(string(name: 'TESTS_KOGITO_EXAMPLES_REF', value: params.EXAMPLES_REF))
+            buildParams.add(string(name: 'TESTS_MAVEN_ARTIFACTS_REPOSITORY_URL', value: env.MAVEN_ARTIFACT_REPOSITORY ?: (isRelease() ? env.DEFAULT_STAGING_REPOSITORY : '')))
 
-void testImage(String imageName) {
-    String testImageTag = "quay.io/kiegroup/${imageName}:${getImageVersion()}"
-    String tempBuiltImageTag = getTempBuiltImageTag(imageName)
-    // Pull and tag to test image
-    sh """
-        docker pull ${tempBuiltImageTag}
-        docker tag ${tempBuiltImageTag} ${testImageTag}
-    """
-    runPythonCommand("make build-image ${getMakeBuildImageArgs()} image_name=${imageName} ignore_build=true ignore_test_prepare=true")
-}
+            buildParams.add(booleanParam(name: 'DEPLOY_IMAGE', value: true))
+            buildParams.add(booleanParam(name: 'DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', value: params.IMAGE_USE_OPENSHIFT_REGISTRY))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_CREDENTIALS', value: params.IMAGE_REGISTRY_CREDENTIALS))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY', value: params.IMAGE_REGISTRY))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_NAMESPACE', value: params.IMAGE_NAMESPACE))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_NAME_SUFFIX', value: params.IMAGE_NAME_SUFFIX))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_TAG', value: params.IMAGE_TAG))
+            buildParams.add(booleanParam(name: 'DEPLOY_WITH_LATEST_TAG', value: params.DEPLOY_WITH_LATEST_TAG))
 
-String getMakeBuildImageArgs() {
-    List args = [ "cekit_option='--work-dir .'" ]
-    args.add("KOGITO_APPS_TARGET_BRANCH=${getKogitoAppsRef()}")
-    if (getKogitoAppsUri()) {
-        args.add("KOGITO_APPS_TARGET_URI=${getKogitoAppsUri()}")
+            def job = build(job: 'kogito-images.build-image', wait: true, parameters: buildParams, propagate: false)
+            if (!job.result == 'SUCCESS') {
+                if (job.result == 'UNSTABLE') {
+                    registerTestFailedImage(image)
+                    unstable("Tests on ${image} seems to have failed")
+                    registerBuiltImage(image)
+                } else {
+                    registerBuildFailedImage(image)
+                    error("Error building ${image}. Please check the logs of the job: ${job.absoluteUrl}")
+                }
+            } else {
+                registerBuiltImage(image)
+            }
+        }
     }
-    args.add("BUILD_ENGINE=${CONTAINER_ENGINE}")
-    if (env.CONTAINER_ENGINE_TLS_OPTIONS) {
-        args.add("BUILD_ENGINE_TLS_OPTIONS=${CONTAINER_ENGINE_TLS_OPTIONS}")
-    }
-    return args.join(' ')
 }
 
 void registerBuiltImage(String imageName) {
@@ -454,12 +324,6 @@ void registerTestFailedImage(String imageName) {
     }
 }
 
-void removeBuiltImage (String imageName) {
-    lock("${BUILD_URL}") {
-        BUILT_IMAGES = BUILT_IMAGES.findAll { it != imageName }
-    }
-}
-
 List getBuiltImages() {
     return BUILT_IMAGES
 }
@@ -468,104 +332,13 @@ List getBuildFailedImages() {
     return BUILD_FAILED_IMAGES
 }
 
-boolean isBuildFailedImage(String imageName) {
-    return BUILD_FAILED_IMAGES.contains(imageName)
-}
-
 List getTestFailedImages() {
     return TEST_FAILED_IMAGES
-}
-
-void pushFinalImages() {
-    for (String imageName : getBuiltImages()) {
-        String tempBuiltImageTag = getTempBuiltImageTag(imageName)
-        pushFinalImage(tempBuiltImageTag, buildImageName(imageName))
-        if (isDeployLatestTag()) {
-            pushFinalImage(tempBuiltImageTag, buildImageName(imageName, 'latest'))
-        }
-        String reducedTag = getReducedTag()
-        if (reducedTag) {
-            pushFinalImage(tempBuiltImageTag, buildImageName(imageName, reducedTag))
-        }
-    }
-}
-
-void pushFinalImage(String oldImageName, String newImageName) {
-    cloud.skopeoCopyRegistryImages(oldImageName, newImageName, Integer.parseInt(env.MAX_REGISTRY_RETRIES))
-}
-
-// Set images public on quay. Useful when new images are introduced.
-void makeQuayImagesPublic() {
-    String namespace = getDeployImageNamespace()
-    for (String imageName : getBuiltImages()) {
-        String repository = getFinalImageName(imageName)
-        echo "Check and set public if needed Quay repository ${namespace}/${repository}"
-        try {
-            cloud.makeQuayImagePublic(namespace, repository, [ usernamePassword: getDeployImageRegistryCredentials()])
-        } catch (err) {
-            echo "[ERROR] Cannot set image quay.io/${namespace}/${repository} as visible"
-        }
-    }
-}
-
-String buildImageName(String imageName, String imageTag = '') {
-    return "${getDeployImageRegistry()}/${getDeployImageNamespace()}/${getFinalImageName(imageName)}:${imageTag ?: getDeployImageTag()}"
-}
-
-String getFinalImageName(String imageName) {
-    return getDeployImageNameSuffix() ? "${imageName}-${getDeployImageNameSuffix()}" : imageName
-}
-
-String getImageVersion() {
-    return runPythonCommand('make display-image-version', true).trim()
-}
-
-String getReducedTag() {
-    try {
-        String version = getDeployImageTag()
-        String[] versionSplit = version.split("\\.")
-        return "${versionSplit[0]}.${versionSplit[1]}"
-    } catch (error) {
-        echo "${getDeployImageTag()} cannot be reduced to the format X.Y"
-    }
-    return ''
-}
-
-void loginOpenshift() {
-    withCredentials([usernamePassword(credentialsId: env.OPENSHIFT_CREDS_KEY, usernameVariable: 'OC_USER', passwordVariable: 'OC_PWD')]) {
-        sh "oc login --username=${OC_USER} --password=${OC_PWD} --server=${env.OPENSHIFT_API} --insecure-skip-tls-verify"
-    }
-}
-
-void loginOpenshiftRegistry() {
-    loginOpenshift()
-    // username can be anything. See https://docs.openshift.com/container-platform/4.4/registry/accessing-the-registry.html#registry-accessing-directly_accessing-the-registry
-    sh "set +x && ${env.CONTAINER_ENGINE} login -u anything -p \$(oc whoami -t) ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${env.OPENSHIFT_REGISTRY}"
-}
-
-void loginContainerRegistry(String registry, String credsId) {
-    withCredentials([usernamePassword(credentialsId: credsId, usernameVariable: 'REGISTRY_USER', passwordVariable: 'REGISTRY_PWD')]) {
-        sh "${env.CONTAINER_ENGINE} login -u ${REGISTRY_USER} -p ${REGISTRY_PWD} ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${registry}"
-    }
-}
-
-void setDeployPropertyIfneeded(String key, def value) {
-    if (value != null && value != '') {
-        deployProperties[key] = value
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Deploy image information
 ////////////////////////////////////////////////////////////////////////
-
-boolean isDeployImageInOpenshiftRegistry() {
-    return params.IMAGE_USE_OPENSHIFT_REGISTRY
-}
-
-String getDeployImageRegistryCredentials() {
-    return params.IMAGE_REGISTRY_CREDENTIALS
-}
 
 String getDeployImageRegistry() {
     return isDeployImageInOpenshiftRegistry() ? env.OPENSHIFT_REGISTRY : params.IMAGE_REGISTRY
@@ -587,35 +360,6 @@ String getDeployImageTag() {
     }
 }
 
-boolean isQuayRegistry() {
-    return getDeployImageRegistry() == 'quay.io'
-}
-
-boolean isDeployLatestTag() {
-    return params.DEPLOY_WITH_LATEST_TAG
-}
-
-////////////////////////////////////////////////////////////////////////
-// Workspaces
-////////////////////////////////////////////////////////////////////////
-
-void initWorkspace(String image) {
-    sh "mkdir -p ${getWorkspacePath(image)}"
-    sh "rsync -av --progress . ${getWorkspacePath(image)} --exclude workspaces"
-}
-
-void cleanWorkspaces() {
-    sh "rm -rf ${getWorkspacesPath()}"
-}
-
-String getWorkspacesPath() {
-    return "${WORKSPACE}/workspaces"
-}
-
-String getWorkspacePath(String image) {
-    return "${getWorkspacesPath()}/${image}"
-}
-
 ////////////////////////////////////////////////////////////////////////
 // utils
 ////////////////////////////////////////////////////////////////////////
@@ -628,20 +372,8 @@ String getRepoName() {
     return env.REPO_NAME
 }
 
-boolean isCreateChangesPR() {
-    return params.CREATE_PR
-}
-
 String getBuildBranch() {
     return params.BUILD_BRANCH_NAME
-}
-
-String getKogitoAppsRef() {
-    return params.APPS_REF ?: getBuildBranch()
-}
-
-String getKogitoAppsUri() {
-    return params.APPS_URI
 }
 
 String getGitAuthor() {
@@ -668,18 +400,6 @@ String getKogitoArtifactsVersion() {
     return params.KOGITO_ARTIFACTS_VERSION
 }
 
-String getMavenArtifactRepository() {
-    return env.MAVEN_ARTIFACT_REPOSITORY ?: (isRelease() ? env.DEFAULT_STAGING_REPOSITORY : '')
-}
-
-boolean shouldSkipTests() {
-    return params.SKIP_TESTS
-}
-
-List getImageBuildPlatforms() {
-    return "${IMAGE_BUILD_PLATFORMS}".split(',') as List
-}
-
 void setDeployPropertyIfNeeded(String key, def value) {
     if (value) {
         deployProperties[key] = value
@@ -688,14 +408,6 @@ void setDeployPropertyIfNeeded(String key, def value) {
 
 String[] getImages() {
     return runPythonCommand("make list | tr '\\n' ','", true).trim().split(',')
-}
-
-boolean isThereAnyChanges() {
-    return sh(script: 'git status --porcelain', returnStdout: true).trim() != ''
-}
-
-String getTempBuiltImageTag(String imageName) {
-    return "localhost:5000/${imageName}:${getImageVersion()}"
 }
 
 void runPythonCommand(String cmd, boolean stdout = false) {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -45,15 +45,14 @@ KogitoJobUtils.createQuarkusUpdateToolsJob(this, 'kogito-images', [:], [:], [], 
 /////////////////////////////////////////////////////////////////
 
 void setupPrJob(boolean isProdCI = false) {
+    setupBuildImageJob(JobType.PULL_REQUEST, '', isProdCI)
+
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'kogito-images', JobType.PULL_REQUEST, "${jenkins_path}/Jenkinsfile", "Kogito Images${isProdCI ? ' Prod' : ''} PR check")
     JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.pr.putAll([
         run_only_for_branches: [ "${GIT_BRANCH}" ],
         disable_status_message_error: true,
         disable_status_message_failure: true,
-    ])
-    jobParams.env.putAll([
-        QUARKUS_PLATFORM_NEXUS_URL: Utils.getMavenQuarkusPlatformRepositoryUrl(this),
     ])
     if (isProdCI) {
         jobParams.job.name += '.prod'
@@ -94,6 +93,8 @@ void createSetupBranchJob() {
 }
 
 void setupDeployJob(JobType jobType, String envName = '') {
+    setupBuildImageJob(jobType, envName)
+
     def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'kogito-images-deploy', jobType, envName, "${jenkins_path}/Jenkinsfile.deploy", 'Kogito Images Deploy')
     JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     if (jobType == JobType.PULL_REQUEST) {
@@ -162,9 +163,52 @@ void setupDeployJob(JobType jobType, String envName = '') {
                 stringParam('QUARKUS_PLATFORM_VERSION', '', 'Allow to override the Quarkus Platform version')
             }
 
-            booleanParam('CREATE_PR', false, 'In case of not releasing, you can ask to create a PR with the changes')
-
             booleanParam('SEND_NOTIFICATION', false, 'In case you want the pipeline to send a notification on CI channel for this run.')
+        }
+    }
+}
+
+void setupBuildImageJob(JobType jobType, String envName = '', boolean prodCI = false) {
+    def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'kogito-images.build-image', jobType, envName, "${jenkins_path}/Jenkinsfile.build-image", 'Kogito Images Build single image')
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    jobParams.env.putAll([
+        MAX_REGISTRY_RETRIES: 3,
+        TARGET_AUTHOR: Utils.getGitAuthor(this), // In case of a PR to merge with target branch
+        PROD_CI: prodCI,
+    ])
+    KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
+        logRotator {
+            daysToKeep(10)
+        }
+        parameters {
+            stringParam('DISPLAY_NAME', '', 'Setup a specific build display name')
+
+            stringParam('BUILD_IMAGE_NAME', '', 'Image name to build. Mandatory parameter.')
+
+            stringParam('SOURCE_AUTHOR', Utils.getGitAuthor(this), 'Build author')
+            stringParam('SOURCE_BRANCH', Utils.getGitBranch(this), 'Build branch name')
+            stringParam('TARGET_BRANCH', '', 'In case of a PR to merge with target branch, please provide the target branch')
+
+            // Build information
+            stringParam('BUILD_KOGITO_APPS_URI', '', 'Git uri to the kogito-apps repository to use for tests.')
+            stringParam('BUILD_KOGITO_APPS_REF', '', 'Git reference (branch/tag) to the kogito-apps repository to use for building. Default to BUILD_BRANCH_NAME.')
+            stringParam('QUARKUS_PLATFORM_URL', Utils.getMavenQuarkusPlatformRepositoryUrl(this), 'URL to the Quarkus platform to use. The version to use will be guessed from artifacts.')
+
+            // Test information
+            booleanParam('SKIP_TESTS', false, 'Skip tests')
+            stringParam('TESTS_KOGITO_EXAMPLES_URI', '', 'Git uri to the kogito-examples repository to use for tests.')
+            stringParam('TESTS_KOGITO_EXAMPLES_REF', '', 'Git reference (branch/tag) to the kogito-examples repository to use for tests.')
+            stringParam('TESTS_MAVEN_ARTIFACTS_REPOSITORY_URL', "${MAVEN_ARTIFACTS_REPOSITORY}")
+
+            // Deploy information
+            booleanParam('DEPLOY_IMAGE', false, 'Should we deploy image to given deploy registry ?')
+            booleanParam('DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('DEPLOY_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS_NIGHTLY}", 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            stringParam('DEPLOY_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Image registry to use to deploy images')
+            stringParam('DEPLOY_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
+            stringParam('DEPLOY_IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
+            stringParam('DEPLOY_IMAGE_TAG', '', 'Image tag to use to deploy images')
+            booleanParam('DEPLOY_WITH_LATEST_TAG', false, 'Set to true if you want the deployed images to also be with the `latest` tag')
         }
     }
 }

--- a/.github/workflows/kogito-images-pr-check.yml
+++ b/.github/workflows/kogito-images-pr-check.yml
@@ -3,6 +3,9 @@ name: Images PR check
 on: pull_request
 jobs:
   bats_test:
+    concurrency:
+      group: ${{ github.repository.name }}_bats_test-${{ github.head_ref }}
+      cancel-in-progress: true
     name: Bats Tests
     runs-on: ubuntu-latest
 
@@ -24,6 +27,9 @@ jobs:
           ./scripts/run-bats.sh
           
   validate_kogito_imagestream:
+    concurrency:
+      group: ${{ github.repository.name }}_validate_kogito_imagestream-${{ github.head_ref }}
+      cancel-in-progress: true
     name: Validate Kogito imagestreams
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +49,9 @@ jobs:
           ${HOME}/openshift-template-validator-linux-amd64 validate -f logic-imagestream.yaml
 
   shellcheck:
+    concurrency:
+      group: ${{ github.repository.name }}_shellcheck-${{ github.head_ref }}
+      cancel-in-progress: true
     name: ShellCheck
     runs-on: ubuntu-latest
 

--- a/kogito-data-index-infinispan-image.yaml
+++ b/kogito-data-index-infinispan-image.yaml
@@ -45,7 +45,6 @@ envs:
 packages:
   manager: microdnf
 
-
 modules:
   repositories:
     - path: modules

--- a/kogito-data-index-infinispan-image.yaml
+++ b/kogito-data-index-infinispan-image.yaml
@@ -45,6 +45,7 @@ envs:
 packages:
   manager: microdnf
 
+
 modules:
   repositories:
     - path: modules

--- a/scripts/build-kogito-apps-components.sh
+++ b/scripts/build-kogito-apps-components.sh
@@ -19,7 +19,7 @@ shift $#
 
 script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
 
-NODE_OPTIONS="${NODE_OPTIONS} --max_old_space_size=4096"
+export NODE_OPTIONS="${NODE_OPTIONS} --max_old_space_size=4096"
 MAVEN_OPTIONS="${MAVEN_OPTIONS} -Dquarkus.package.type=fast-jar -Dquarkus.build.image=false"
 # used for all-in-one image
 extended_context=""

--- a/tests/test-apps/clone-repo.sh
+++ b/tests/test-apps/clone-repo.sh
@@ -8,8 +8,7 @@ if [ -n "${IMAGE_NAME}" ]; then
     if [[ ${IMAGE_NAME} =~ rhpam|logic* ]]; then
         prod="--prod"
     fi
-    python3 ../../scripts/list-images.py ${prod} -is ${IMAGE_NAME}
-    if [ $? = 0 ]; then
+    if python3 ../../scripts/list-images.py ${prod} -is ${IMAGE_NAME}; then
         echo "Target image is supporting services, skipping examples build"
         exit 0
     fi


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-9351

Depends on https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/282

I exported the build/test/push single image into a standalone job.
That way the PR check or the deploy, will call that job for each image, in parallel.

Pros:
- One central jenkinsfile to build&test image, no copy/paste
- No space issue anymore and no parallel build conflict

Cons:
- may take some time before jenkins assign a node, but it is usually a matter of minutes

Follow-up: [Be able to retrieve test results from downstream called jobs](https://issues.redhat.com/browse/KOGITO-9418)