### PR TITLE
build-quarkus-app.sh: allow to copy local deployed artifacts when running as part of nightly

### DIFF
--- a/scripts/logic/build-quarkus-app.sh
+++ b/scripts/logic/build-quarkus-app.sh
@@ -52,6 +52,12 @@ if [ "${CI}" = "true" ]; then
 fi
 mkdir -p ${mvn_local_repo}
 
+if [ "${NIGHTLY}" = "true" ]; then
+    # In case of a nightly, the Kogito/Drools artifacts are not deployed anywhere, so they need to be copied
+    # inside the maven repo local folder
+    cp -rp ${NIGHTLY_DEPLOY_FOLDER}/* ${mvn_local_repo}
+fi
+
 set -x
 echo "Create quarkus project to path ${build_target_dir}"
 cd ${build_target_dir}


### PR DESCRIPTION
`build-quarkus-app.sh` script uses `-Dmaven.repo.local` and points to a clean folder, so the Kogito artifacts built as part of the nightly (that are not deployed anywhere yet) can't be found.

This PR allows, in case of a nightly, to copy the Kogito/Drools artifacts deployed locally to the same path that `-Dmaven.repo.local` points, so the artifacts can be resolved.

…


Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>