### PR TITLE
CI: Build Image job should use build branch jenkinsfile

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -170,6 +170,9 @@ void setupDeployJob(JobType jobType, String envName = '') {
 
 void setupBuildImageJob(JobType jobType, String envName = '', boolean prodCI = false) {
     def jobParams = JobParamsUtils.getBasicJobParamsWithEnv(this, 'kogito-images.build-image', jobType, envName, "${jenkins_path}/Jenkinsfile.build-image", 'Kogito Images Build single image')
+    // Use jenkinsfile from the build branch
+    jobParams.git.author = '${SOURCE_AUTHOR}'
+    jobParams.git.branch = '${SOURCE_BRANCH}'
     JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.env.putAll([
         MAX_REGISTRY_RETRIES: 3,
@@ -187,17 +190,17 @@ void setupBuildImageJob(JobType jobType, String envName = '', boolean prodCI = f
 
             stringParam('SOURCE_AUTHOR', Utils.getGitAuthor(this), 'Build author')
             stringParam('SOURCE_BRANCH', Utils.getGitBranch(this), 'Build branch name')
-            stringParam('TARGET_BRANCH', '', 'In case of a PR to merge with target branch, please provide the target branch')
+            stringParam('TARGET_BRANCH', '', '(Optional) In case of a PR to merge with target branch, please provide the target branch')
 
             // Build information
-            stringParam('BUILD_KOGITO_APPS_URI', '', 'Git uri to the kogito-apps repository to use for tests.')
-            stringParam('BUILD_KOGITO_APPS_REF', '', 'Git reference (branch/tag) to the kogito-apps repository to use for building. Default to BUILD_BRANCH_NAME.')
+            stringParam('BUILD_KOGITO_APPS_URI', '', '(Optional) Git uri to the kogito-apps repository to use for tests.')
+            stringParam('BUILD_KOGITO_APPS_REF', '', '(Optional) Git reference (branch/tag) to the kogito-apps repository to use for building. Default to BUILD_BRANCH_NAME.')
             stringParam('QUARKUS_PLATFORM_URL', Utils.getMavenQuarkusPlatformRepositoryUrl(this), 'URL to the Quarkus platform to use. The version to use will be guessed from artifacts.')
 
             // Test information
             booleanParam('SKIP_TESTS', false, 'Skip tests')
-            stringParam('TESTS_KOGITO_EXAMPLES_URI', '', 'Git uri to the kogito-examples repository to use for tests.')
-            stringParam('TESTS_KOGITO_EXAMPLES_REF', '', 'Git reference (branch/tag) to the kogito-examples repository to use for tests.')
+            stringParam('TESTS_KOGITO_EXAMPLES_URI', '', '(Optional) Git uri to the kogito-examples repository to use for tests.')
+            stringParam('TESTS_KOGITO_EXAMPLES_REF', '', '(Optional) Git reference (branch/tag) to the kogito-examples repository to use for tests.')
             stringParam('TESTS_MAVEN_ARTIFACTS_REPOSITORY_URL', "${MAVEN_ARTIFACTS_REPOSITORY}")
 
             // Deploy information


### PR DESCRIPTION
Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>