### PR TITLE
Fix feature format and add a feature file to builder image tests

### DIFF
--- a/tests/features/kogito-swf-builder.feature
+++ b/tests/features/kogito-swf-builder.feature
@@ -1,4 +1,5 @@
 @quay.io/kiegroup/kogito-swf-builder
+@openshift-serverless-1-tech-preview/logic-swf-builder-rhel8
 Feature: Serverless Workflow builder images
 
   Scenario: Verify that the application is built and started correctly

--- a/tests/features/openshift-serverless-logic/logic-data-index-ephemeral.feature
+++ b/tests/features/openshift-serverless-logic/logic-data-index-ephemeral.feature
@@ -1,5 +1,5 @@
 @openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8
-Feature: logic-data-index-ephemeral-rhel8 feature.
+Feature: logic-data-index-ephemeral-rhel8 feature
 
   Scenario: verify if all labels are correctly set on logic-data-index-ephemeral-rhel8 image
     Given image is built

--- a/tests/features/openshift-serverless-logic/logic-swf-builder.feature
+++ b/tests/features/openshift-serverless-logic/logic-swf-builder.feature
@@ -1,5 +1,5 @@
 @openshift-serverless-1-tech-preview/logic-swf-builder-rhel8
-Feature: logic-swf-builder-rhel8 feature.
+Feature: logic-swf-builder-rhel8 feature
 
   Scenario: verify if all labels are correctly set on logic-swf-builder-rhel8 image
     Given image is built

--- a/tests/features/openshift-serverless-logic/logic-swf-devmode.feature
+++ b/tests/features/openshift-serverless-logic/logic-swf-devmode.feature
@@ -1,5 +1,5 @@
 @openshift-serverless-1-tech-preview/logic-swf-devmode-rhel8
-Feature: logic-swf-devmode-rhel8 feature.
+Feature: logic-swf-devmode-rhel8 feature
 
   Scenario: verify if all labels are correctly set on logic-swf-devmode-rhel8 image
     Given image is built


### PR DESCRIPTION
Many thanks for submitting your Pull Request :racing_car: ! 

This solves:
* jUnit format parsing issues on Jenkins
* Missing inclusion of `kogito-swf-builder.feature` file for the `logic-swf-builder-rhel8` image tests

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>