### PR TITLE
KOGITO-5386: added a new parameter for unique branch name

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -26,8 +26,6 @@ pipeline {
     environment {
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
-        PR_BRANCH_HASH = "${util.generateHash(10)}"
-
         OPENSHIFT_REGISTRY = credentials('OPENSHIFT_REGISTRY')
     }
 
@@ -67,6 +65,9 @@ pipeline {
             }
             steps {
                 script {
+                    if (githubscm.isBranchExist('origin',getPRBranch())) {
+                        githubscm.removeRemoteBranch('origin', getPRBranch())
+                    }
                     githubscm.createBranch(getPRBranch())
                 }
             }
@@ -395,7 +396,7 @@ String getGitAuthorCredsID() {
 }
 
 String getPRBranch() {
-    return "${getProjectVersion() ?: getBuildBranch()}-${env.PR_BRANCH_HASH}"
+    return params.KOGITO_PR_BRANCH
 }
 
 String getProjectVersion() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -171,6 +171,7 @@ void setupDeployJob(JobType jobType, String envName = '') {
                 stringParam('QUARKUS_PLATFORM_VERSION', '', 'Allow to override the Quarkus Platform version')
             }
 
+            stringParam('KOGITO_PR_BRANCH', '', 'PR branch name')
             booleanParam('SEND_NOTIFICATION', false, 'In case you want the pipeline to send a notification on CI channel for this run.')
         }
     }


### PR DESCRIPTION
JIRA: [5386](https://issues.redhat.com/browse/KOGITO-5386)

related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/1024
- https://github.com/kiegroup/kogito-runtimes/pull/3161
- https://github.com/kiegroup/kogito-apps/pull/1820
- https://github.com/kiegroup/kogito-examples/pull/1757
- https://github.com/kiegroup/kogito-images/pull/1666
- https://github.com/kiegroup/kogito-operator/pull/1504
- https://github.com/kiegroup/kogito-serverless-operator/pull/218

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [ ] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>