### PR TITLE
[KOGITO-9749] - Add Events Process, Process Management, and Sources addon to builder image

### DIFF
--- a/modules/kogito-swf/builder/build-config/module.yaml
+++ b/modules/kogito-swf/builder/build-config/module.yaml
@@ -9,4 +9,4 @@ envs:
   - name: QUARKUS_EXTENSIONS
     # NOTE: If you change the QUARKUS_EXTENSIONS value remember to update the scripts/logic/build-quarkus-app.sh too!
     # Follow up issue to remove KOGITO_VERSION: https://issues.redhat.com/browse/KOGITO-9270
-    value: quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing,smallrye-health,org.kie.kogito:kogito-addons-quarkus-fabric8-kubernetes-service-catalog:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-kubernetes:${KOGITO_VERSION}
+    value: quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing,smallrye-health,org.kie.kogito:kogito-addons-quarkus-fabric8-kubernetes-service-catalog:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-kubernetes:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-events-process:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-process-management:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-source-files:${KOGITO_VERSION}

--- a/scripts/logic/build-quarkus-app.sh
+++ b/scripts/logic/build-quarkus-app.sh
@@ -22,6 +22,8 @@ quarkus_extensions_arch_specific="com.aayushatharva.brotli4j:native-linux-aarch6
 quarkus_extensions="quarkus-kubernetes,kogito-quarkus-serverless-workflow,kogito-addons-quarkus-knative-eventing,smallrye-health,org.kie.kogito:kogito-addons-quarkus-fabric8-kubernetes-service-catalog:${kogito_version},org.kie.kogito:kogito-addons-quarkus-kubernetes:${kogito_version}"
 # dev mode purpose extensions used only by the kogito-swf-devmode
 kogito_swf_devmode_extensions="kogito-quarkus-serverless-workflow-devui,kogito-addons-quarkus-source-files,kogito-addons-quarkus-process-management,org.kie.kogito:kogito-addons-quarkus-jobs-service-embedded:${kogito_version},org.kie.kogito:kogito-addons-quarkus-data-index-inmemory:${kogito_version}"
+# builder/prod extensitons used only by the kogito-swf-builder
+kogito_swf_builder_extensions="org.kie.kogito:kogito-addons-quarkus-events-process:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-process-management:${KOGITO_VERSION},org.kie.kogito:kogito-addons-quarkus-source-files:${KOGITO_VERSION}"
 
 if [ -z ${quarkus_platform_version} ]; then
     echo "Please provide the quarkus version"
@@ -30,7 +32,7 @@ fi
 
 case ${image_name} in
     "kogito-swf-builder")
-        quarkus_extensions="${quarkus_extensions},${quarkus_extensions_arch_specific}"
+        quarkus_extensions="${quarkus_extensions},${kogito_swf_builder_extensions},${quarkus_extensions_arch_specific}"
         ;;
     "kogito-swf-devmode")
         quarkus_extensions="${quarkus_extensions},${kogito_swf_devmode_extensions},${quarkus_extensions_arch_specific}"


### PR DESCRIPTION
In this PR, we introduce a few addons required for integration with Data Index, Jobs Services, and Management Console in the prod mode.

See: https://issues.redhat.com/browse/KOGITO-9749

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>

- <b>Prod tests</b>  
  Please add comment: <b>Jenkins (re)run [prod|Prod|PROD]</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>