### PR TITLE
kie-issues#749: fix nightly build and tests

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-and-test
+++ b/.ci/jenkins/Jenkinsfile.build-and-test
@@ -15,6 +15,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
+                    util.waitForDocker()
                     sh 'printenv'
                     
                     dir(getRepoName()) {

--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -28,6 +28,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
+                    util.waitForDocker()
                     sh 'printenv'
 
                     assert getBuildImageName() : 'Please provide `BUILD_IMAGE_NAME` parameter'

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -29,6 +29,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
+                    util.waitForDocker()
                     currentBuild.displayName = params.DISPLAY_NAME ?: currentBuild.displayName
 
                     dir(getRepoName()) {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -33,11 +33,10 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    clean()
-
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME
                     }
+                    util.waitForDocker()
 
                     readDeployProperties()
 
@@ -61,8 +60,6 @@ pipeline {
                     dir(getRepoName()) {
                         checkoutRepo()
                     }
-
-                    cloud.installSkopeo()
                 }
             }
         }
@@ -139,12 +136,6 @@ void checkoutRepo() {
     checkout(githubscm.resolveRepository(getRepoName(), getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsId()))
     // need to manually checkout branch since on a detached branch after checkout command
     sh "git checkout ${getBuildBranch()}"
-}
-
-void clean() {
-    cleanWs()
-    util.cleanNode()
-    cloud.cleanSkopeo()
 }
 
 void promoteImages() {

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -450,7 +450,7 @@ def update_examples_uri_in_clone_repo(examples_uri):
     """
     print("Set examples_uri {} in clone-repo script".format(examples_uri))
     pattern = re.compile(r'(git clone.*)')
-    replacement = "git clone {}".format(examples_uri)
+    replacement = "git clone {} kogito-examples".format(examples_uri)
     update_in_file(CLONE_REPO_SCRIPT, pattern, replacement)
 
 def update_maven_repo_in_build_config(repo_url, replace_default_repository):

--- a/tests/features/common-custom-truststore.feature
+++ b/tests/features/common-custom-truststore.feature
@@ -18,7 +18,7 @@
 @openshift-serverless-1-tech-preview/logic-data-index-ephemeral-rhel8
 Feature: Common tests for Custom TrustStore configuration
   Scenario: Verify if a custom certificate is correctly handled
-    When container is started with command bash -c "sleep 5s; /home/kogito/kogito-app-launch.sh"
+    When container is started with command bash -c "sleep 10s; /home/kogito/kogito-app-launch.sh"
       | variable            | value              |
       | CUSTOM_TRUSTSTORE   | my-truststore.jks  |
       | RUNTIME_TYPE        | quarkus            |


### PR DESCRIPTION
Fixes:
* apache/incubator-kie-issues#749

Fixing tests by
* increasing leading sleep time in one of the feature files
* adjusting clone-repo.sh rewriting python script which was dropping target directory for git clone command

Tweaking stability by adding explicit wait for docker daemon to be started.