### PR TITLE
kie-issues#759: make git clone pattern more robust

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -449,8 +449,8 @@ def update_examples_uri_in_clone_repo(examples_uri):
     :param examples_uri: kogito-examples uri
     """
     print("Set examples_uri {} in clone-repo script".format(examples_uri))
-    pattern = re.compile(r'(git clone.*)')
-    replacement = "git clone {} kogito-examples".format(examples_uri)
+    pattern = re.compile(r'(git clone \S+)')
+    replacement = "git clone {}".format(examples_uri)
     update_in_file(CLONE_REPO_SCRIPT, pattern, replacement)
 
 def update_maven_repo_in_build_config(repo_url, replace_default_repository):


### PR DESCRIPTION
Fixes
- apache/incubator-kie-issues#759

Tweak the pattern to replace git clone command only up to (including) the url, leaving possible path argument intact.