### PR TITLE
FLPATH-1066: swf-builder: generate manifests using kn-workflow

### DIFF
--- a/kogito-swf-builder-image.yaml
+++ b/kogito-swf-builder-image.yaml
@@ -68,7 +68,9 @@
         - name: org.kie.kogito.project.versions
         - name: org.kie.kogito.swf.common.scripts
         - name: org.kie.kogito.swf.builder.runtime.community
+        - name: org.kie.kogito.workflow-manifests
 
     run:
       workdir: "/home/kogito/${PROJECT_ARTIFACT_ID}"
       user: 1001
+

--- a/modules/kogito-swf/common/scripts/added/build-app.sh
+++ b/modules/kogito-swf/common/scripts/added/build-app.sh
@@ -62,3 +62,5 @@ cd ${KOGITO_HOME}/serverless-workflow-project
     -DskipTests \
     -Dquarkus.container-image.build=false \
     clean install
+
+"${script_dir_path}"/generate-manifests.sh "${resources_path}"

--- a/modules/kogito-workflow-manifests/added/generate-manifests.sh
+++ b/modules/kogito-workflow-manifests/added/generate-manifests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash 
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -x
+resource_dir="${1:-${KOGITO_HOME}/serverless-workflow-project/src/main/resources}"
+target_dir="${KOGITO_HOME}/build/manifests"
+if [ "${GEN_MANIFESTS}" = "true" ]; then
+    # kn-workflow doesn't support source dir yet, we have to get in
+    pushd "${resource_dir}" || exit
+    kn-workflow gen-manifest --custom-generated-manifests-dir "${target_dir}" --namespace ""
+    popd || exit
+fi
+

--- a/modules/kogito-workflow-manifests/configure
+++ b/modules/kogito-workflow-manifests/configure
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash 
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+set -x
+
+cp /tmp/artifacts/kn-workflow-"$(uname --machine)" /usr/local/bin/kn-workflow
+chmod +x-w /usr/local/bin/kn-workflow
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp -v "${SCRIPT_DIR}"/added/* "${KOGITO_HOME}"/launch
+
+chown -R 1001:0 "${KOGITO_HOME}"/launch
+chmod -R ug+rwX "${KOGITO_HOME}"/launch

--- a/modules/kogito-workflow-manifests/module.yaml
+++ b/modules/kogito-workflow-manifests/module.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+schema_version: 1
+name: org.kie.kogito.workflow-manifests
+version: "999-SNAPSHOT"
+description: Module to install kn-workflow tool and scripts
+execute:
+  - script: configure
+envs:
+  - name: KN_CLI
+    value: /usr/local/bin/kn-workflow
+  - name: GEN_MANIFESTS
+    value: false
+
+artifacts:
+  - name: kn-workflow-x86_64
+    url: https://github.com/rgolangh/kie-tools/releases/download/0.0.2/kn-workflow-linux-amd64
+    md5: defdb771fd65d47c0255fd4389127656

--- a/modules/kogito-workflow-manifests/tests/bats/kogito-workflow-manifest.bats
+++ b/modules/kogito-workflow-manifests/tests/bats/kogito-workflow-manifest.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+setup() {
+    export KOGITO_HOME=/tmp/kogito
+    export HOME="${KOGITO_HOME}"
+    mkdir -p "${KOGITO_HOME}"/launch
+    mock_bin kn-workflow
+    mkdir -p "${KOGITO_HOME}"/serverless-workflow-project/src/main/resources/schemas
+
+    touch "${KOGITO_HOME}"/launch/configure-jvm-mvn.sh
+    cp $BATS_TEST_DIRNAME/../../added/generate-manifests.sh "${KOGITO_HOME}"/launch/
+    cp $BATS_TEST_DIRNAME/../../../kogito-logging/added/logging.sh "${KOGITO_HOME}"/launch/
+    cp $BATS_TEST_DIRNAME/../../../kogito-swf/common/scripts/added/build-app.sh "${KOGITO_HOME}"/launch/
+}
+
+teardown() {
+    rm -rf "${KOGITO_HOME}"
+    rm -rf /tmp/resources
+}
+
+@test "verify generate manifest is working" {
+    TEMPD=$(mktemp -d)
+    cp -r $BATS_TEST_DIRNAME/../../../../tests/shell/kogito-swf-builder/resources/greet-with-inputschema/* ${TEMPD}
+
+    # opt-in to generate-manifests
+    export GEN_MANIFESTS=true
+    # We don't care about the errors to try to execute and build the program, just the copy matters
+    source ${KOGITO_HOME}/launch/build-app.sh ${TEMPD} || true
+
+    # this tests the call to kn-workflow actually happend
+    [ -f "${KOGITO_HOME}"/bin/kn-workflow_invocation.txt ] 
+}
+
+@test "verify generate manifest is an opt-in" {
+    TEMPD=$(mktemp -d)
+    cp -r $BATS_TEST_DIRNAME/../../../../tests/shell/kogito-swf-builder/resources/greet-with-inputschema/* ${TEMPD}
+
+    # opt-out to generate-manifests
+    export GEN_MANIFESTS=false
+    # We don't care about the errors to try to execute and build the program, just the copy matters
+    source ${KOGITO_HOME}/launch/build-app.sh ${TEMPD} || true
+
+    # this tests that the call to kn-workflow didn't happend
+    [ ! -f "${KOGITO_HOME}"/bin/kn-workflow_invocation.txt ] 
+}
+
+mock_bin() {
+    mkdir -p "${KOGITO_HOME}"/bin
+    PATH+=":${KOGITO_HOME}/bin/"
+    cat << EOF > "${KOGITO_HOME}"/bin/$1
+    echo $1 "$@" > $"${KOGITO_HOME}"/bin/$1_invocation.txt
+EOF
+    chmod +x "${KOGITO_HOME}"/bin/$1
+}
+


### PR DESCRIPTION
Generate manifests and save them in the runtime image.

Generating manifests is an opt-in as part of the build ran by /launch/build-app.sh
When setting `GEN_MANIFESTS=true` during container build the build-app.sh
script will call a new generate-manifests.sh script that will use
_kn-workflow_ cli and will store the manifests under
`$KOGITO_HOME/build/manifests`

Later in the runtime image user can copy and store those manifests for
later use:
  ```
  COPY --from=builder --chown=185 /home/kogito/build/manifests /deployments/manifests
  ```
The manifests can be extracted for example by echoing them from the image:
  ```
  podman run builder:latest cat /deployment/manifests/* > manifests-all.yaml
  ```

or by podman cp:

  ```
  podman cp $(podman create builder:latest):/deployment/manifests .
  ```

Fixes: #1739
Related-to: https://issues.redhat.com/browse/FLPATH-1066

Signed-off-by: Roy Golan <rgolan@redhat.com>

Many thanks for submitting your Pull Request :heart:! 

Please make sure your PR meets the following requirements:

- [x] You have read the [contributors guide](README.md#contributing-to-kogito-images-repository)
- [ ] Pull Request title is properly formatted: `[KOGITO|RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Your feature/bug fix has a testcase that verifies it
- [ ] You've tested the new feature/bug fix in an actual OpenShift cluster
- [ ] You've added a [RELEASE_NOTES.md](RELEASE_NOTES.md) entry regarding this change

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

- <b>(Re)run Jenkins tests</b>  
  Please add comment: <b>Jenkins [test|retest] this</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
