### PR TITLE
[kie-issues#1038] Temporary removal of kogito-swf-{builder-,devmode} images from release pipelines

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -441,7 +441,10 @@ String[] getImages() {
     if (env.IMAGES_LIST) {
         return env.IMAGES_LIST.split(',')
     }
-    return sh(returnStdout: true, script: "make list | tr '\\n' ','").trim().split(',')
+    String images = sh(returnStdout: true, script: "make list | tr '\\n' ','").trim()
+    // Temporary removal of kogito-swf-* images that have been moved to kie-tools for the Apache 10 release
+    images = images.replace("kogito-swf-builder,", "").replace("kogito-swf-devmode,", "")
+    return images.split(',')
 }
 
 String getQuarkusPlatformVersion() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -366,6 +366,8 @@ String getNewImageTag() {
 
 String[] getImages() {
     String images = getOldImageNames() ?: env.IMAGES_LIST ?: runPythonCommand("make list | tr '\\n' ','", true).trim()
+    // Temporary removal of kogito-swf-* images that have been moved to kie-tools for the Apache 10 release
+    images = images.replace("kogito-swf-builder,", "").replace("kogito-swf-devmode,", "")
     return images.split(',')
 }
 


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/1038

This PR removes the kogito-swf-buider and kogito-swf-devmode images from the automation pipelines.

Those 2 images are being moved to kie-tools repository for the Apache 10 release.