### PR TITLE
kie-issues#1214: Replace explicit references to quay.io images across CI pipelines

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -66,8 +66,8 @@ pipeline {
                         if (isDeployImageInOpenshiftRegistry()) {
                             cloud.loginOpenShift(getOpenShiftAPI(), env.OPENSHIFT_CREDS_KEY)
                             cloud.loginOpenshiftRegistry(env.CONTAINER_ENGINE, env.CONTAINER_ENGINE_TLS_OPTIONS ?: '')
-                        } else if (getDeployImageRegistryCredentials()) {
-                            cloud.loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryCredentials(), env.CONTAINER_ENGINE, env.CONTAINER_ENGINE_TLS_OPTIONS ?: '')
+                        } else if (getDeployImageRegistryUserCredentialsId() && getDeployImageRegistryTokenCredentialsId()) {
+                            cloud.loginContainerRegistry(getDeployImageRegistry(), getDeployImageRegistryUserCredentialsId(), getDeployImageRegistryTokenCredentialsId(), env.CONTAINER_ENGINE, env.CONTAINER_ENGINE_TLS_OPTIONS ?: '')
                         }
                     }
                 }
@@ -295,8 +295,12 @@ boolean isDeployImageInOpenshiftRegistry() {
     return params.DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY
 }
 
-String getDeployImageRegistryCredentials() {
-    return params.DEPLOY_IMAGE_REGISTRY_CREDENTIALS
+String getDeployImageRegistryUserCredentialsId() {
+    return params.DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID
+}
+
+String getDeployImageRegistryTokenCredentialsId() {
+    return params.DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID
 }
 
 String getDeployImageRegistry() {

--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -16,11 +16,9 @@
  */
 @Library('jenkins-pipeline-shared-libraries')_
 
-QUAY_REGISTRY = 'quay.io'
-
 pipeline {
     agent {
-        docker { 
+        docker {
             image env.AGENT_DOCKER_BUILDER_IMAGE
             args env.AGENT_DOCKER_BUILDER_ARGS
             label util.avoidFaultyNodes()
@@ -149,18 +147,6 @@ pipeline {
             }
             steps {
                 script {
-                    // Make public if quay registry
-                    if (getDeployImageRegistry() == QUAY_REGISTRY) {
-                        String namespace = getDeployImageNamespace()
-                        String repository = getFinalImageName()
-                        echo "Check and set public if needed Quay repository ${namespace}/${repository}"
-                        try {
-                            cloud.makeQuayImagePublic(namespace, repository, [ usernamePassword: getDeployImageRegistryCredentials()])
-                        } catch (err) {
-                            echo "[ERROR] Cannot set image quay.io/${namespace}/${repository} as visible"
-                        }
-                    }
-
                     int retries = Integer.parseInt(env.MAX_REGISTRY_RETRIES)
                     String imageTag = getBuiltImageTag()
                     if (isDeployLatestTag()) {
@@ -228,7 +214,7 @@ pipeline {
             }
             steps {
                 script {
-                    def resultingFileName = "${getFinalImageName()}.tar.gz"
+                    def resultingFileName = "incubator-kie-${getReleaseVersion()}-${getBuildImageName()}.tar.gz"
                     def signatureFileName = "${resultingFileName}.asc"
                     sh """
                         docker pull ${getBuiltImageTag()}
@@ -328,9 +314,8 @@ String getDeployImageNameSuffix() {
 String getDeployImageTag() {
     if (params.DEPLOY_IMAGE_TAG != '') {
         return params.DEPLOY_IMAGE_TAG
-    } else {
-        return sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
     }
+    return sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
 }
 
 String getFinalImageName() {
@@ -470,4 +455,8 @@ String getReleaseSvnRepository() {
 
 String getReleaseSvnCredsId() {
     return env.RELEASE_SVN_CREDS_ID
+}
+
+String getReleaseVersion() {
+    return env.RELEASE_VERSION
 }

--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -214,7 +214,7 @@ pipeline {
             }
             steps {
                 script {
-                    def resultingFileName = "incubator-kie-${getReleaseVersion()}-${getBuildImageName()}.tar.gz"
+                    def resultingFileName = "incubator-kie-${getImageArtifactReleaseVersion()}-${getBuildImageName()}.tar.gz"
                     def signatureFileName = "${resultingFileName}.asc"
                     sh """
                         docker pull ${getBuiltImageTag()}
@@ -222,7 +222,7 @@ pipeline {
                     """
                     release.gpgImportKeyFromFileWithPassword(getReleaseGpgSignKeyCredsId(), getReleaseGpgSignPassphraseCredsId())
                     release.gpgSignFileDetachedSignatureWithPassword(resultingFileName, signatureFileName, getReleaseGpgSignPassphraseCredsId())
-                    release.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getReleaseVersion(), resultingFileName, signatureFileName)
+                    release.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getImageArtifactReleaseVersion(), resultingFileName, signatureFileName)
                 }
             }
             post {
@@ -457,6 +457,6 @@ String getReleaseSvnCredsId() {
     return env.RELEASE_SVN_CREDS_ID
 }
 
-String getReleaseVersion() {
-    return env.RELEASE_VERSION
+String getImageArtifactReleaseVersion() {
+    return env.IMAGE_ARTIFACT_RELEASE_VERSION
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -228,7 +228,7 @@ pipeline {
                         setDeployPropertyIfNeeded("${getRepoName()}.pr.source.ref", getPRBranch())
                         setDeployPropertyIfNeeded("${getRepoName()}.pr.target.uri", "https://github.com/${getGitAuthor()}/${getRepoName()}")
                         setDeployPropertyIfNeeded("${getRepoName()}.pr.target.ref", getBuildBranch())
-                        setDeployPropertyIfNeeded("${getRepoName()}.tag.name", geGitTagName())
+                        setDeployPropertyIfNeeded("${getRepoName()}.tag.name", getGitTagName())
                     }
                 }
             }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -213,6 +213,12 @@ pipeline {
                         }
                         String prLink = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getGitAuthorPushCredsId())
                         deployProperties["${getRepoName()}.pr.link"] = prLink
+
+
+                        // Create a new tag
+                        githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
+                        githubscm.tagRepository(getProjectVersion())
+                        githubscm.pushRemoteTag('origin', getProjectVersion(), getGitAuthorPushCredsId())
                     }
                 }
             }
@@ -227,6 +233,7 @@ pipeline {
                 }
             }
         }
+
         stage('Finalize') {
             steps {
                 script {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -308,6 +308,7 @@ void createBuildAndTestStageClosure(String image) {
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAME_SUFFIX', value: getDeployImageNameSuffix()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_TAG', value: getDeployImageTag()))
             buildParams.add(booleanParam(name: 'DEPLOY_WITH_LATEST_TAG', value: isDeployLatestTag()))
+            buildParams.add(string(name: 'RELEASE_VERSION', value: getProjectVersion()))
 
             def job = build(job: 'kogito-images.build-image', wait: true, parameters: buildParams, propagate: false)
             if (job.result != 'SUCCESS') {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -214,11 +214,10 @@ pipeline {
                         String prLink = githubscm.createPR(commitMsg, prBody, getBuildBranch(), getGitAuthorPushCredsId())
                         deployProperties["${getRepoName()}.pr.link"] = prLink
 
-
                         // Create a new tag
                         githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
-                        githubscm.tagRepository(getProjectVersion())
-                        githubscm.pushRemoteTag('origin', getProjectVersion(), getGitAuthorPushCredsId())
+                        githubscm.tagRepository(getGitTagName())
+                        githubscm.pushRemoteTag('origin', getGitTagName(), getGitAuthorPushCredsId())
                     }
                 }
             }
@@ -229,6 +228,7 @@ pipeline {
                         setDeployPropertyIfNeeded("${getRepoName()}.pr.source.ref", getPRBranch())
                         setDeployPropertyIfNeeded("${getRepoName()}.pr.target.uri", "https://github.com/${getGitAuthor()}/${getRepoName()}")
                         setDeployPropertyIfNeeded("${getRepoName()}.pr.target.ref", getBuildBranch())
+                        setDeployPropertyIfNeeded("${getRepoName()}.tag.name", geGitTagName())
                     }
                 }
             }
@@ -315,7 +315,7 @@ void createBuildAndTestStageClosure(String image) {
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAME_SUFFIX', value: getDeployImageNameSuffix()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_TAG', value: getDeployImageTag()))
             buildParams.add(booleanParam(name: 'DEPLOY_WITH_LATEST_TAG', value: isDeployLatestTag()))
-            buildParams.add(string(name: 'RELEASE_VERSION', value: getProjectVersion()))
+            buildParams.add(string(name: 'IMAGE_ARTIFACT_RELEASE_VERSION', value: getGitTagName()))
 
             def job = build(job: 'kogito-images.build-image', wait: true, parameters: buildParams, propagate: false)
             if (job.result != 'SUCCESS') {
@@ -458,4 +458,8 @@ String[] getImages() {
 
 String getQuarkusPlatformVersion() {
     return params.QUARKUS_PLATFORM_VERSION
+}
+
+String getGitTagName() {
+    return params.GIT_TAG_NAME
 }

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -309,7 +309,8 @@ void createBuildAndTestStageClosure(String image) {
 
             buildParams.add(booleanParam(name: 'DEPLOY_IMAGE', value: isDeployImage()))
             buildParams.add(booleanParam(name: 'DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', value: isDeployImageInOpenshiftRegistry()))
-            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_CREDENTIALS', value: getDeployImageRegistryCredentials()))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID', value: getDeployImageRegistryUserCredentialsId()))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', value: getDeployImageRegistryTokenCredentialsId()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY', value: getDeployImageRegistry()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAMESPACE', value: getDeployImageNamespace()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAME_SUFFIX', value: getDeployImageNameSuffix()))
@@ -370,8 +371,12 @@ boolean isDeployImageInOpenshiftRegistry() {
     return params.IMAGE_USE_OPENSHIFT_REGISTRY
 }
 
-String getDeployImageRegistryCredentials() {
-    return params.IMAGE_REGISTRY_CREDENTIALS
+String getDeployImageRegistryUserCredentialsId() {
+    return params.IMAGE_REGISTRY_USER_CREDENTIALS_ID
+}
+
+String getDeployImageRegistryTokenCredentialsId() {
+    return params.IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID
 }
 
 String getDeployImageRegistry() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -64,15 +64,15 @@ pipeline {
                     // Login old registry
                     if (isOldImageInOpenshiftRegistry()) {
                         loginOpenshiftRegistry()
-                    } else if (getOldImageRegistryCredentials() != '') {
-                        loginContainerRegistry(getOldImageRegistry(), getOldImageRegistryCredentials())
+                    } else if (getOldImageRegistryUserCredentialsId() != '' && getOldImageRegistryTokenCredentialsId() != '') {
+                        loginContainerRegistry(getOldImageRegistry(), getOldImageRegistryUserCredentialsId(), getOldImageRegistryTokenCredentialsId())
                     }
 
                     // Login new registry
                     if (isNewImageInOpenshiftRegistry()) {
                         loginOpenshiftRegistry()
-                    } else if (getNewImageRegistryCredentials() != '') {
-                        loginContainerRegistry(getNewImageRegistry(), getNewImageRegistryCredentials())
+                    } else if (getNewImageRegistryUserCredentialsId() != '' && getNewImageRegistryTokenCredentialsId() != '') {
+                        loginContainerRegistry(getNewImageRegistry(), getNewImageRegistryUserCredentialsId(), getNewImageRegistryTokenCredentialsId())
                     }
 
                     dir(getRepoName()) {
@@ -212,9 +212,11 @@ void loginOpenshiftRegistry() {
     sh "set +x && ${env.CONTAINER_ENGINE} login -u anything -p \$(oc whoami -t) ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${env.OPENSHIFT_REGISTRY}"
 }
 
-void loginContainerRegistry(String registry, String credsId) {
-    withCredentials([usernamePassword(credentialsId: credsId, usernameVariable: 'REGISTRY_USER', passwordVariable: 'REGISTRY_PWD')]) {
-        sh "${env.CONTAINER_ENGINE} login -u ${REGISTRY_USER} -p ${REGISTRY_PWD} ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${registry}"
+void loginContainerRegistry(String registry, String userCredsId, String tokenCredsId) {
+    withCredentials([string(credentialsId: userCredsId, variable: 'DOCKER_USER')]) {
+        withCredentials([string(credentialsId: tokenCredsId, variable: 'DOCKER_TOKEN')]) {
+            sh "${env.CONTAINER_ENGINE} login -u ${DOCKER_USER} -p ${DOCKER_TOKEN} ${env.CONTAINER_ENGINE_TLS_OPTIONS ?: ''} ${registry}"
+        }
     }
 }
 
@@ -294,8 +296,12 @@ boolean isOldImageInOpenshiftRegistry() {
     return params.BASE_IMAGE_USE_OPENSHIFT_REGISTRY
 }
 
-String getOldImageRegistryCredentials() {
-    return params.BASE_IMAGE_REGISTRY_CREDENTIALS
+String getOldImageRegistryUserCredentialsId() {
+    return params.BASE_IMAGE_REGISTRY_USER_CREDENTIALS_ID
+}
+
+String getOldImageRegistryTokenCredentialsId() {
+    return params.BASE_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID
 }
 
 String getOldImageRegistry() {
@@ -326,8 +332,12 @@ boolean isNewImageInOpenshiftRegistry() {
     return params.PROMOTE_IMAGE_USE_OPENSHIFT_REGISTRY
 }
 
-String getNewImageRegistryCredentials() {
-    return params.PROMOTE_IMAGE_REGISTRY_CREDENTIALS
+String getNewImageRegistryUserCredentialsId() {
+    return params.PROMOTE_IMAGE_REGISTRY_USER_CREDENTIALS_ID
+}
+
+String getNewImageRegistryTokenCredentialsId() {
+    return params.PROMOTE_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID
 }
 
 String getNewImageRegistry() {

--- a/.ci/jenkins/Jenkinsfile.promote
+++ b/.ci/jenkins/Jenkinsfile.promote
@@ -173,20 +173,6 @@ void promoteImage(String oldImageName, String newImageName) {
     cloud.skopeoCopyRegistryImages(oldImageName, newImageName, Integer.parseInt(env.MAX_REGISTRY_RETRIES))
 }
 
-// Set images public on quay. Useful when new images are introduced.
-void makeQuayNewImagesPublic() {
-    String namespace = getNewImageNamespace()
-    for (String imageName : getImages()) {
-        String repository = getFinalImageName(imageName, getNewImageNameSuffix())
-        echo "Check and set public if needed Quay repository ${namespace}/${repository}"
-        try {
-            cloud.makeQuayImagePublic(namespace, repository, [ usernamePassword: getNewImageRegistryCredentials()])
-        } catch (err) {
-            echo "[ERROR] Cannot set image quay.io/${namespace}/${repository} as visible"
-        }
-    }
-}
-
 String getOldImageFullTag(String imageName) {
     return "${getOldImageRegistry()}/${getOldImageNamespace()}/${getFinalImageName(imageName, getOldImageNameSuffix())}:${getOldImageTag()}"
 }
@@ -294,10 +280,6 @@ String getGitAuthorCredsId() {
 
 String getGitAuthorPushCredsId() {
     return env.GIT_AUTHOR_PUSH_CREDS_ID
-}
-
-boolean isQuayRegistry(String registry) {
-    return registry == 'quay.io'
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/.ci/jenkins/Jenkinsfile.weekly.deploy
+++ b/.ci/jenkins/Jenkinsfile.weekly.deploy
@@ -206,7 +206,8 @@ void createBuildAndTestStageClosure(String image) {
 
             buildParams.add(booleanParam(name: 'DEPLOY_IMAGE', value: true))
             buildParams.add(booleanParam(name: 'DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', value: isDeployImageInOpenshiftRegistry()))
-            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_CREDENTIALS', value: getDeployImageRegistryCredentials()))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID', value: getDeployImageRegistryUserCredentialsId()))
+            buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', value: getDeployImageRegistryTokenCredentialsId()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_REGISTRY', value: getDeployImageRegistry()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAMESPACE', value: getDeployImageNamespace()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAME_SUFFIX', value: getDeployImageNameSuffix()))
@@ -262,8 +263,12 @@ boolean isDeployImageInOpenshiftRegistry() {
     return params.IMAGE_USE_OPENSHIFT_REGISTRY
 }
 
-String getDeployImageRegistryCredentials() {
-    return params.IMAGE_REGISTRY_CREDENTIALS
+String getDeployImageRegistryUserCredentialsId() {
+    return params.IMAGE_REGISTRY_USER_CREDENTIALS_ID
+}
+
+String getDeployImageRegistryTokenCredentialsId() {
+    return params.IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID
 }
 
 String getDeployImageRegistry() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -210,6 +210,7 @@ void setupBuildImageJob(JobType jobType) {
             stringParam('DEPLOY_IMAGE_TAG', '', 'Image tag to use to deploy images')
             booleanParam('DEPLOY_WITH_LATEST_TAG', false, 'Set to true if you want the deployed images to also be with the `latest` tag')
             booleanParam('EXPORT_AND_GPG_SIGN_IMAGE', jobType == JobType.RELEASE, 'Set to true if should images be exported and signed.')
+            stringParam('RELEASE_VERSION', '', 'Set the release version to be attached to the images artifacts names')
         }
     }
 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -136,8 +136,9 @@ void setupDeployJob(JobType jobType) {
             stringParam('EXAMPLES_REF', '', 'Git reference (branch/tag) to the kogito-examples repository to use for tests.')
 
             // Deploy information
-            booleanParam('IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
-            stringParam('IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS}", 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            booleanParam('IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_USER_CREDENTIALS_ID, IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('IMAGE_REGISTRY_USER_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_USER_CREDENTIALS_ID}", 'Image registry user credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            stringParam('IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID}", 'Image registry token credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
             stringParam('IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Image registry to use to deploy images')
             stringParam('IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
             stringParam('IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
@@ -203,8 +204,9 @@ void setupBuildImageJob(JobType jobType) {
 
             // Deploy information
             booleanParam('DEPLOY_IMAGE', false, 'Should we deploy image to given deploy registry ?')
-            booleanParam('DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
-            stringParam('DEPLOY_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS}", 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            booleanParam('DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID, DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID, DEPLOY_IMAGE_REGISTRY and DEPLOY_IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_USER_CREDENTIALS_ID}", 'Image registry user credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            stringParam('DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID}", 'Image registry token credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
             stringParam('DEPLOY_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Image registry to use to deploy images')
             stringParam('DEPLOY_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
             stringParam('DEPLOY_IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
@@ -260,8 +262,9 @@ void setupBuildAndTestJob(JobType jobType) {
 
             // Deploy information
             booleanParam('DEPLOY_IMAGE', false, 'Should we deploy image to given deploy registry ?')
-            booleanParam('DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
-            stringParam('DEPLOY_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS}", 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            booleanParam('DEPLOY_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID, DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID, DEPLOY_IMAGE_REGISTRY and DEPLOY_IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('DEPLOY_IMAGE_REGISTRY_USER_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_USER_CREDENTIALS_ID}", 'Image registry user credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            stringParam('DEPLOY_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID}", 'Image registry token credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
             stringParam('DEPLOY_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Image registry to use to deploy images')
             stringParam('DEPLOY_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
             stringParam('DEPLOY_IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')
@@ -302,8 +305,9 @@ void setupPromoteJob(JobType jobType) {
             stringParam('DEPLOY_BUILD_URL', '', 'URL to jenkins deploy build to retrieve the `deployment.properties` file. If base parameters are defined, they will override the `deployment.properties` information')
 
             // Base images information which can override `deployment.properties`
-            booleanParam('BASE_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Override `deployment.properties`. Set to true if base image should be retrieved from Openshift registry.In this case, BASE_IMAGE_REGISTRY_CREDENTIALS, BASE_IMAGE_REGISTRY and BASE_IMAGE_NAMESPACE parameters will be ignored')
-            stringParam('BASE_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS}", 'Override `deployment.properties`. Base Image registry credentials to use to deploy images. Will be ignored if no BASE_IMAGE_REGISTRY is given')
+            booleanParam('BASE_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Override `deployment.properties`. Set to true if base image should be retrieved from Openshift registry.In this case, BASE_IMAGE_REGISTRY_USER_CREDENTIALS_ID, BASE_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID, BASE_IMAGE_REGISTRY and BASE_IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('BASE_IMAGE_REGISTRY_USER_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_USER_CREDENTIALS_ID}", 'Override `deployment.properties`. Base Image registry user credentials id to use to deploy images. Will be ignored if no BASE_IMAGE_REGISTRY is given')
+            stringParam('BASE_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID}", 'Override `deployment.properties`. Base Image registry token credentials id to use to deploy images. Will be ignored if no BASE_IMAGE_REGISTRY is given')
             stringParam('BASE_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Override `deployment.properties`. Base image registry')
             stringParam('BASE_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Override `deployment.properties`. Base image namespace')
             stringParam('BASE_IMAGE_NAMES', '', 'Override `deployment.properties`. Comma separated list of images')
@@ -311,8 +315,9 @@ void setupPromoteJob(JobType jobType) {
             stringParam('BASE_IMAGE_TAG', '', 'Override `deployment.properties`. Base image tag')
 
             // Promote images information
-            booleanParam('PROMOTE_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if base image should be deployed in Openshift registry.In this case, PROMOTE_IMAGE_REGISTRY_CREDENTIALS, PROMOTE_IMAGE_REGISTRY and PROMOTE_IMAGE_NAMESPACE parameters will be ignored')
-            stringParam('PROMOTE_IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS}", 'Promote Image registry credentials to use to deploy images. Will be ignored if no PROMOTE_IMAGE_REGISTRY is given')
+            booleanParam('PROMOTE_IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if base image should be deployed in Openshift registry.In this case, PROMOTE_IMAGE_REGISTRY_USER_CREDENTIALS_ID, PROMOTE_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID, PROMOTE_IMAGE_REGISTRY and PROMOTE_IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('PROMOTE_IMAGE_REGISTRY_USER_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_USER_CREDENTIALS_ID}", 'Promote Image registry user credentials id to use to deploy images. Will be ignored if no PROMOTE_IMAGE_REGISTRY is given')
+            stringParam('PROMOTE_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID}", 'Promote Image registry token credentials id to use to deploy images. Will be ignored if no PROMOTE_IMAGE_REGISTRY is given')
             stringParam('PROMOTE_IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Promote image registry')
             stringParam('PROMOTE_IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Promote image namespace')
             stringParam('PROMOTE_IMAGE_NAME_SUFFIX', '', 'Promote image name suffix')
@@ -375,8 +380,9 @@ void setupWeeklyDeployJob(JobType jobType) {
             stringParam('EXAMPLES_REF', '', 'Git reference (branch/tag) to the kogito-examples repository to use for tests.')
 
             // Deploy information
-            booleanParam('IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_CREDENTIALS, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
-            stringParam('IMAGE_REGISTRY_CREDENTIALS', "${CLOUD_IMAGE_REGISTRY_CREDENTIALS}", 'Image registry credentials to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            booleanParam('IMAGE_USE_OPENSHIFT_REGISTRY', false, 'Set to true if image should be deployed in Openshift registry.In this case, IMAGE_REGISTRY_USER_CREDENTIALS_ID, IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID, IMAGE_REGISTRY and IMAGE_NAMESPACE parameters will be ignored')
+            stringParam('IMAGE_REGISTRY_USER_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_USER_CREDENTIALS_ID}", 'Image registry user credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
+            stringParam('IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID', "${CLOUD_IMAGE_REGISTRY_TOKEN_CREDENTIALS_ID}", 'Image registry token credentials id to use to deploy images. Will be ignored if no IMAGE_REGISTRY is given')
             stringParam('IMAGE_REGISTRY', "${CLOUD_IMAGE_REGISTRY}", 'Image registry to use to deploy images')
             stringParam('IMAGE_NAMESPACE', "${CLOUD_IMAGE_NAMESPACE}", 'Image namespace to use to deploy images')
             stringParam('IMAGE_NAME_SUFFIX', '', 'Image name suffix to use to deploy images. In case you need to change the final image name, you can add a suffix to it.')

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -149,6 +149,7 @@ void setupDeployJob(JobType jobType) {
             stringParam('KOGITO_ARTIFACTS_VERSION', '', 'Optional. If artifacts\' version is different from PROJECT_VERSION.')
             if (jobType == JobType.RELEASE) {
                 stringParam('QUARKUS_PLATFORM_VERSION', '', 'Allow to override the Quarkus Platform version')
+                stringParam('GIT_TAG_NAME', '', 'Git tag to be created')
             }
 
             stringParam('KOGITO_PR_BRANCH', '', 'PR branch name')
@@ -210,7 +211,7 @@ void setupBuildImageJob(JobType jobType) {
             stringParam('DEPLOY_IMAGE_TAG', '', 'Image tag to use to deploy images')
             booleanParam('DEPLOY_WITH_LATEST_TAG', false, 'Set to true if you want the deployed images to also be with the `latest` tag')
             booleanParam('EXPORT_AND_GPG_SIGN_IMAGE', jobType == JobType.RELEASE, 'Set to true if should images be exported and signed.')
-            stringParam('RELEASE_VERSION', '', 'Set the release version to be attached to the images artifacts names')
+            stringParam('IMAGE_ARTIFACT_RELEASE_VERSION', '', 'Set the release version to be attached to the images artifacts names')
         }
     }
 }


### PR DESCRIPTION
This PR is part of [#1214](https://github.com/apache/incubator-kie-issues/issues/1214):

- Removed references for quay.io on CI scripts
- Added a new pipeline parameter to set the release version in the docker images artifact names
- Added tag creation for releases
- Added new apache dockerhub credentials

Depends on: https://github.com/apache/incubator-kie-kogito-pipelines/pull/1207