### PR TITLE
incubator-kie-kogito-images#1729: PR checks forks with different naming

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-and-test
+++ b/.ci/jenkins/Jenkinsfile.build-and-test
@@ -38,7 +38,15 @@ pipeline {
                     dir(getRepoName()) {
                         // TODO Test pupose
                         deleteDir()
-                        githubscm.checkoutIfExists(getRepoName(), getChangeAuthor(), getChangeBranch(), 'apache', getChangeTarget(), true, credentials = [token: getGitAuthorTokenCredentialsId(), usernamePassword: getGitAuthorCredentialsId()])
+                        if (getTargetBranch()) {
+                            echo 'Got a target branch ... Trying to merge the source with the target'
+                            githubscm.checkoutIfExists(getRepoName(), getSourceAuthor(), getSourceBranch(), getTargetAuthor(), getTargetBranch(), true, [ token: getGitAuthorTokenCredentialsId(), usernamePassword: getGitAuthorCredentialsId() ])
+                            githubscm.prepareCommitStatusInformationForPullRequest(getSourceRepository(), getSourceAuthor(), getSourceBranch(), getTargetAuthor(), getGitAuthorCredentialsId())
+                        } else {
+                            echo 'No target branch ... Checking out simply'
+                            githubscm.checkout(githubscm.resolveRepository(getSourceRepository(), getSourceAuthor(), getSourceBranch(), false, getGitAuthorCredentialsId()))
+                            githubscm.prepareCommitStatusInformation(getSourceRepository(), getSourceAuthor(), getSourceBranch(), getGitAuthorCredentialsId())
+                        }
                     }
                 }
             }
@@ -62,7 +70,6 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
-                        githubscm.prepareCommitStatusInformationForPullRequest(getRepoName(), getChangeAuthor(), getChangeBranch(), 'apache', getGitAuthorCredentialsId())
                         parallelStages = [:]
                         for(String image : getImages()){
                             parallelStages[image] = createBuildAndTestStageClosure(image)
@@ -88,8 +95,9 @@ Closure createBuildAndTestStageClosure(String image) {
             List buildParams = []
             buildParams.add(string(name: "DISPLAY_NAME", value: "PR #${getChangeId()} - ${image}: ${getChangeUrl()}"))
             buildParams.add(string(name: 'BUILD_IMAGE_NAME', value: image))
-            buildParams.add(string(name: 'SOURCE_AUTHOR', value: getChangeAuthor()))
-            buildParams.add(string(name: 'SOURCE_BRANCH', value: getChangeBranch()))
+            buildParams.add(string(name: 'SOURCE_AUTHOR', value: getSourceAuthor()))
+            buildParams.add(string(name: 'SOURCE_REPOSITORY', value: getSourceRepository()))
+            buildParams.add(string(name: 'SOURCE_BRANCH', value: getSourceBranch()))
             buildParams.add(string(name: 'TARGET_BRANCH', value: getChangeTarget()))
             buildParams.add(string(name: 'BUILD_KOGITO_APPS_REF', value: getChangeTarget()))
 
@@ -115,28 +123,36 @@ String[] getImages() {
     return sh(returnStdout: true, script: "make list | tr '\\n' ','").trim().split(',')
 }
 
-String getChangeAuthor() {
-    return SOURCE_AUTHOR
+String getSourceAuthor() {
+    return params.SOURCE_AUTHOR
 }
 
-String getChangeBranch() {
-    return SOURCE_BRANCH
+String getSourceBranch() {
+    return params.SOURCE_BRANCH
+}
+
+String getSourceRepository() {
+    return params.SOURCE_REPOSITORY
 }
 
 String getChangeTarget() {
-    return TARGET_BRANCH
+    return params.TARGET_BRANCH
 }
 
 String getChangeId() {
-    return CHANGE_ID
+    return params.CHANGE_ID
 }
 
 String getChangeUrl() {
-    return CHANGE_URL
+    return params.CHANGE_URL
 }
 
 String getRepoName() {
     return env.REPO_NAME
+}
+
+String getTargetAuthor() {
+    return env.TARGET_AUTHOR
 }
 
 String getGitAuthorCredentialsId() {

--- a/.ci/jenkins/Jenkinsfile.build-and-test
+++ b/.ci/jenkins/Jenkinsfile.build-and-test
@@ -155,6 +155,10 @@ String getTargetAuthor() {
     return env.TARGET_AUTHOR
 }
 
+String getTargetBranch() {
+    return params.TARGET_BRANCH
+}
+
 String getGitAuthorCredentialsId() {
     return env.GIT_AUTHOR_CREDS_ID
 }

--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -52,11 +52,11 @@ pipeline {
                     if (getTargetBranch()) {
                         echo 'Got a target branch ... Trying to merge the source with the target'
                         githubscm.checkoutIfExists(getRepoName(), getSourceAuthor(), getSourceBranch(), getTargetAuthor(), getTargetBranch(), true, [ token: getGitAuthorTokenCredentialsId(), usernamePassword: getGitAuthorCredentialsId() ])
-                        githubscm.prepareCommitStatusInformationForPullRequest(getRepoName(), getSourceAuthor(), getSourceBranch(), getTargetAuthor(), getGitAuthorCredentialsId())
+                        githubscm.prepareCommitStatusInformationForPullRequest(getSourceRepository(), getSourceAuthor(), getSourceBranch(), getTargetAuthor(), getGitAuthorCredentialsId())
                     } else {
                         echo 'No target branch ... Checking out simply'
-                        checkout(githubscm.resolveRepository(getRepoName(), getSourceAuthor(), getSourceBranch(), false, getGitAuthorCredentialsId()))
-                        githubscm.prepareCommitStatusInformation(getRepoName(), getSourceAuthor(), getSourceBranch(), getGitAuthorCredentialsId())
+                        checkout(githubscm.resolveRepository(getSourceRepository(), getSourceAuthor(), getSourceBranch(), false, getGitAuthorCredentialsId()))
+                        githubscm.prepareCommitStatusInformation(getSourceRepository(), getSourceAuthor(), getSourceBranch(), getGitAuthorCredentialsId())
                     }
                     githubscm.setUserConfig('robot', 'kie.apache.org', true)
                     updateGithubCommitStatus('PENDING', 'Started')
@@ -359,6 +359,10 @@ String getBuildImageName() {
 
 String getSourceAuthor() {
     return params.SOURCE_AUTHOR
+}
+
+String getSourceRepository() {
+    return params.SOURCE_REPOSITORY
 }
 
 String getSourceBranch() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -187,6 +187,7 @@ void setupBuildImageJob(JobType jobType) {
             stringParam('BUILD_IMAGE_NAME', '', 'Image name to build. Mandatory parameter.')
 
             stringParam('SOURCE_AUTHOR', Utils.getGitAuthor(this), 'Build author')
+            stringParam('SOURCE_REPOSITORY', Utils.getRepoName(this), 'Build repository name')
             stringParam('SOURCE_BRANCH', Utils.getGitBranch(this), 'Build branch name')
             stringParam('TARGET_BRANCH', '', '(Optional) In case of a PR to merge with target branch, please provide the target branch')
 


### PR DESCRIPTION
Addressing:
* #1729 

Problems were caused by the `githubscm.prepareCommitStatusInformation*` methods that don't resolve the fork name.

To overcome this limitation, using propagation of the env variables from the PR check plugin into the jenkinsfiles of Jenkinsfile.build-and-test and Jenkinsfile.build-image .

By setting sensible defaults for the job parameters the changes should be covering both PR check and nightly build use cases.

The githubscm.checkoutIfExists method does the merging into target branch out of the box - that's why the execution differs for PR check vs nightly. In theory, we know which repo to resolve, so could be unified, but we'd need to handle the merging differently (which might be less convenient afterall).
