### PR TITLE
incubator-kie-kogito-images#1729: parameterize jobParams of build-ima…

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -163,6 +163,7 @@ void setupBuildImageJob(JobType jobType) {
     def jobParams = JobParamsUtils.getBasicJobParams(this, 'kogito-images.build-image', jobType, "${jenkins_path}/Jenkinsfile.build-image", 'Kogito Images Build single image')
     // Use jenkinsfile from the build branch
     jobParams.git.author = '${SOURCE_AUTHOR}'
+    jobParams.git.repository = '${SOURCE_REPOSITORY}'
     jobParams.git.branch = '${SOURCE_BRANCH}'
     JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
     jobParams.env.putAll([


### PR DESCRIPTION
…ge job

Complements
* #1776 

Adjusting build-image jobParams in DSL to reference parameter value SOURCE_REPOSITORY which enables executing build-image jobs on a user fork which does not match the target repository name.