### PR TITLE
kie-issues#1387: Adjust pipelines to use the gpg key provided by Apache to sign the artifacts

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -220,8 +220,8 @@ pipeline {
                         docker pull ${getBuiltImageTag()}
                         docker save ${getBuiltImageTag()} | gzip > ${resultingFileName}
                     """
-                    release.gpgImportKeyFromFileWithPassword(getReleaseGpgSignKeyCredsId(), getReleaseGpgSignPassphraseCredsId())
-                    release.gpgSignFileDetachedSignatureWithPassword(resultingFileName, signatureFileName, getReleaseGpgSignPassphraseCredsId())
+                    release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
+                    release.gpgSignFileDetachedSignatureWithoutPassword(resultingFileName, signatureFileName)
                     release.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getImageArtifactReleaseVersion(), resultingFileName, signatureFileName)
                 }
             }


### PR DESCRIPTION
Part of: https://github.com/apache/incubator-kie-issues/issues/1387