### PR TITLE
NO-ISSUE: fix setup-branch cleanWs problem

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -39,7 +39,7 @@ pipeline {
         stage('Initialization') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
 
                     if (params.DISPLAY_NAME) {
                         currentBuild.displayName = params.DISPLAY_NAME


### PR DESCRIPTION
Quick fix to prevent the cleanWs asynchronously deleting things for the following steps on the go.