### PR TITLE
NO-ISSUE: Do not publish images with reduced tags

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -153,12 +153,6 @@ pipeline {
                         latestTag = getTriggeringProjectName().contains('weekly') ? 'weekly-latest' : 'latest'
                         cloud.skopeoCopyRegistryImages(imageTag, getBuiltImageTag(latestTag), retries)
                     }
-                    try {
-                        String reducedTag = cloud.getReducedTag(getDeployImageTag())
-                        cloud.skopeoCopyRegistryImages(imageTag, getBuiltImageTag(reducedTag), retries)
-                    } catch (err) {
-                        echo "Reduced tag cannot be applied: ${err}"
-                    }
                 }
             }
         }


### PR DESCRIPTION
This PR removes the code to publish reduced tags which was causing to deploy images with the final tag: `10.0`