### PR TITLE
[10.0.x] NO-ISSUE: set 10.0.x as a tag

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -53,7 +53,7 @@ pipeline {
             steps {
                 script {
                     dir(getRepoName()) {
-                        versionCmd = "python scripts/manage-kogito-version.py --bump-to ${getKogitoVersion()} --confirm"
+                        versionCmd = "python scripts/manage-kogito-version.py --bump-to ${getBuildBranch()} --confirm"
                         versionCmd += " --examples-ref nightly-${getBuildBranch()}"
                         if (getKogitoArtifactsVersion()) {
                             versionCmd += " --artifacts-version ${getKogitoArtifactsVersion()}"

--- a/scripts/manage-kogito-version.py
+++ b/scripts/manage-kogito-version.py
@@ -51,8 +51,8 @@ if __name__ == "__main__":
 
     if args.bump_to:
         # validate if the provided version is valid.
-        # e.g. 1.10.0, 1.0.0-rc1, 999-snapshot or 999-20240101-snapshot
-        pattern = r'(\d+.\d+.)?(\d+$|\d+-rc\d+$|\d+(-\d{8})?-snapshot$)'
+        # e.g. 1.10.0, 10.0.x, 1.0.0-rc1, 999-snapshot or 999-20240101-snapshot
+        pattern = r'(\d+.\d+.)?(x$|\d+$|\d+-rc\d+$|\d+(-\d{8})?-snapshot$)'
         regex = re.compile(pattern, re.IGNORECASE)
         valid = regex.match(args.bump_to)
         examples_ref = ""


### PR DESCRIPTION
Adjusting manage-kogito-version.py script to allow bumping versions to 10.0.x

The value `args.bump_to`, when containing `10.0.x`, might not be valid for all place where applied - because the value is also used as defaults e.g. for `artifacts_version` (maven versions), but script offers sufficient override options.

By allowing 10.0.x and adjusting setup-branch job to actually set such value, we don't need any special precautions when building nightlies (like prefixing a tag or what not). Actually those prefixes `nightly-` were removed some time ago, when we agreed that nightly tag would actually be `10.0.x` for `10.0.x` branches.