### PR TITLE
[10.0.x] NO-ISSUE: fix env.DISABLE_IMAGES_DEPLOY evaluation

### DIFF
--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -364,7 +364,7 @@ List getTestFailedImages() {
 ////////////////////////////////////////////////////////////////////////
 
 boolean isDeployImage() {
-    return !env.DISABLE_IMAGES_DEPLOY
+    return !Boolean.valueOf(env.DISABLE_IMAGES_DEPLOY)
 }
 
 boolean isDeployImageInOpenshiftRegistry() {


### PR DESCRIPTION
Fixing boolean evaluation of env.DISABLE_IMAGES_DEPLOY variable.

Tested by "re-playing" the 10.0.x pipelines in Jenkins which resulted in correct param.DEPLOY_IMAGE being passed to the `build-image` job variant.