### PR TITLE
[10.0.x] NO-ISSUE: Update release utils file

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -214,9 +214,9 @@ pipeline {
                         docker pull ${getBuiltImageTag()}
                         docker save ${getBuiltImageTag()} | gzip > ${resultingFileName}
                     """
-                    release.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
-                    release.gpgSignFileDetachedSignatureWithoutPassword(resultingFileName, signatureFileName)
-                    release.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getImageArtifactReleaseVersion(), resultingFileName, signatureFileName)
+                    releaseUtils.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
+                    releaseUtils.gpgSignFileDetachedSignatureWithoutPassword(resultingFileName, signatureFileName)
+                    releaseUtils.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getImageArtifactReleaseVersion(), resultingFileName, signatureFileName)
                 }
             }
             post {


### PR DESCRIPTION
The release.grovvy file has been renamed to releaseUtils.groovy on [jenkins-pipeline-shared-libraries](https://github.com/apache/incubator-kie-kogito-pipelines/tree/10.0.x/jenkins-pipeline-shared-libraries/vars).

This PR updates the deploy job to use the new name.