### PR TITLE
NO-ISSUE: Restrict images deploy only for release jobs

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -117,7 +117,7 @@ void setupDeployJob(JobType jobType) {
 
         QUARKUS_PLATFORM_NEXUS_URL: Utils.getMavenQuarkusPlatformRepositoryUrl(this),
 
-        DISABLE_IMAGES_DEPLOY: (jobType==JobType.NIGHTLY) ? true : Utils.isImagesDeployDisabled(this)
+        DISABLE_IMAGES_DEPLOY: (jobType == JobType.RELEASE) ? true : Utils.isImagesDeployDisabled(this)
     ])
     if (Utils.hasBindingValue(this, 'CLOUD_IMAGES')) {
         jobParams.env.put('IMAGES_LIST', Utils.getBindingValue(this, 'CLOUD_IMAGES'))


### PR DESCRIPTION
We should only restrict images deploy on release jobs.