### PR TITLE
NO-ISSUE: Fix Git tag creation in the weekly deploy Jenkins job execution

### DIFF
--- a/.ci/jenkins/Jenkinsfile.weekly.deploy
+++ b/.ci/jenkins/Jenkinsfile.weekly.deploy
@@ -128,7 +128,13 @@ pipeline {
                 script {
                     projectVersion = getProjectVersion()
                     dir(getRepoName()) {
-                        githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
+                        if (githubscm.isThereAnyChanges()) {
+                            def commitMsg = "[${getBuildBranch()}] Update version to ${projectVersion}"
+                            githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
+                            githubscm.commitChanges(commitMsg, { githubscm.findAndStageNotIgnoredFiles('pom.xml') })
+                        } else {
+                            println '[WARN] no changes to commit'
+                        }
                         githubscm.tagRepository(projectVersion)
                         githubscm.pushRemoteTag('origin', projectVersion, getGitAuthorPushCredsId())
                     }


### PR DESCRIPTION
This PR updates the tag creation during the weekly deploy job execution to commit the changes (version update) before pushing the new tag.