### PR TITLE
NO-ISSUE: Fix git commit for tag creation on the weekly deploy Jenkins job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.weekly.deploy
+++ b/.ci/jenkins/Jenkinsfile.weekly.deploy
@@ -131,7 +131,7 @@ pipeline {
                         if (githubscm.isThereAnyChanges()) {
                             def commitMsg = "[${getBuildBranch()}] Update version to ${projectVersion}"
                             githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
-                            githubscm.commitChanges(commitMsg, { githubscm.findAndStageNotIgnoredFiles('pom.xml') })
+                            githubscm.commitChanges(commitMsg)
                         } else {
                             println '[WARN] no changes to commit'
                         }


### PR DESCRIPTION
This PR fixes the git commit command that we run before creating the weekly snapshot git tag.