### PR TITLE
[10.0.x] NO-ISSUE: Fix apache release image artifact names

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-image
+++ b/.ci/jenkins/Jenkinsfile.build-image
@@ -212,7 +212,7 @@ pipeline {
             }
             steps {
                 script {
-                    String resultingFileName = "incubator-kie-${getImageArtifactReleaseVersion()}-${getBuildImageName()}-image.tar.gz"
+                    String resultingFileName = "apache-kie-${getImageArtifactReleaseVersion()}-incubating-${getBuildImageName()}-image.tar.gz"
                     String signatureFileName = "${resultingFileName}.asc"
                     String checksumFileName = "${resultingFileName}.sha512"
                     sh """
@@ -222,7 +222,7 @@ pipeline {
                     """
                     releaseUtils.gpgImportKeyFromStringWithoutPassword(getReleaseGpgSignKeyCredsId())
                     releaseUtils.gpgSignFileDetachedSignatureWithoutPassword(resultingFileName, signatureFileName)
-                    releaseUtils.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getImageArtifactReleaseVersion(), resultingFileName, signatureFileName, checksumFileName)
+                    releaseUtils.svnUploadFileToRepository(getReleaseSvnRepository(), getReleaseSvnCredsId(), getImageArtifactReleaseCandidateVersion(), resultingFileName, signatureFileName, checksumFileName)
                 }
             }
             post {
@@ -470,6 +470,10 @@ String getReleaseSvnCredsId() {
 
 String getImageArtifactReleaseVersion() {
     return params.IMAGE_ARTIFACT_RELEASE_VERSION
+}
+
+String getImageArtifactReleaseCandidateVersion() {
+    return params.IMAGE_ARTIFACT_RELEASE_CANDIDATE_VERSION
 }
 
 boolean isRelease() {

--- a/.ci/jenkins/Jenkinsfile.deploy
+++ b/.ci/jenkins/Jenkinsfile.deploy
@@ -126,6 +126,21 @@ pipeline {
             }
         }
 
+        stage('Commit and Tag changes') {
+            when {
+                expression { return isRelease() }
+            }
+            steps {
+                script {
+                    if (!getBuildFailedImages()) {
+                        dir(getRepoName()) {
+                            commitAndTagChanges("[${getBuildBranch()}] Update version to ${getProjectVersion()}")
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Build, Push & Test Images') {
             steps {
                 script {
@@ -148,21 +163,6 @@ pipeline {
                         setDeployPropertyIfNeeded("${imgPrefix}.names", getBuiltImages().join(','))
                         setDeployPropertyIfNeeded("${imgPrefix}.name-suffix", getDeployImageNameSuffix())
                         setDeployPropertyIfNeeded("${imgPrefix}.tag", getDeployImageTag())
-                    }
-                }
-            }
-        }
-
-        stage('Commit and Tag changes') {
-            when {
-                expression { return isRelease() }
-            }
-            steps {
-                script {
-                    if (!getBuildFailedImages()) {
-                        dir(getRepoName()) {
-                            commitAndTagChanges("[${getBuildBranch()}] Update version to ${getProjectVersion()}")
-                        }
                     }
                 }
             }
@@ -252,7 +252,8 @@ void createBuildAndTestStageClosure(String image) {
             buildParams.add(string(name: 'DEPLOY_IMAGE_NAME_SUFFIX', value: getDeployImageNameSuffix()))
             buildParams.add(string(name: 'DEPLOY_IMAGE_TAG', value: getDeployImageTag()))
             buildParams.add(booleanParam(name: 'DEPLOY_WITH_LATEST_TAG', value: isDeployLatestTag()))
-            buildParams.add(string(name: 'IMAGE_ARTIFACT_RELEASE_VERSION', value: getGitTagName()))
+            buildParams.add(string(name: 'IMAGE_ARTIFACT_RELEASE_VERSION', value: getProjectVersion()))
+            buildParams.add(string(name: 'IMAGE_ARTIFACT_RELEASE_CANDIDATE_VERSION', value: getGitTagName()))
 
             def job = build(job: 'kogito-images.build-image', wait: true, parameters: buildParams, propagate: false)
             if (job.result != 'SUCCESS') {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -118,7 +118,7 @@ void setupDeployJob(JobType jobType) {
         QUARKUS_PLATFORM_NEXUS_URL: Utils.getMavenQuarkusPlatformRepositoryUrl(this),
 
         // during 10.0.x release automated push of images is disabled, in nightly behaves based on configuration in branch.yaml
-        DISABLE_IMAGES_DEPLOY: (jobType==JobType.NIGHTLY) ? Utils.isImagesDeployDisabled(this) : true
+        DISABLE_IMAGES_DEPLOY: (jobType == JobType.RELEASE) ? true : Utils.isImagesDeployDisabled(this)
     ])
     if (Utils.hasBindingValue(this, 'CLOUD_IMAGES')) {
         jobParams.env.put('IMAGES_LIST', Utils.getBindingValue(this, 'CLOUD_IMAGES'))
@@ -218,6 +218,7 @@ void setupBuildImageJob(JobType jobType) {
             booleanParam('DEPLOY_WITH_LATEST_TAG', false, 'Set to true if you want the deployed images to also be with the `latest` tag')
             booleanParam('EXPORT_AND_GPG_SIGN_IMAGE', jobType == JobType.RELEASE, 'Set to true if should images be exported and signed.')
             stringParam('IMAGE_ARTIFACT_RELEASE_VERSION', '', 'Optional if not RELEASE. Set the release version to be attached to the images artifacts names')
+            stringParam('IMAGE_ARTIFACT_RELEASE_CANDIDATE_VERSION', '', 'Optional if not RELEASE. Set the release candidate version to define the SVN directory where the images artifacts will be uploaded')
         }
     }
 }


### PR DESCRIPTION
This PR updates the name of the image artifacts that we push to the Apache staging SVN when releasing a new version.

The expected format is: `apache-kie-10.0.0-incubating-{image-name}`